### PR TITLE
Allow curl to follow redirects

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -42,7 +42,7 @@ COPY nominatim.conf /etc/apache2/sites-enabled/000-default.conf
 
 # Load initial data
 ENV PBF_DATA http://download.geofabrik.de/europe/monaco-latest.osm.pbf
-RUN curl $PBF_DATA --create-dirs -o /app/src/data.osm.pbf
+RUN curl -L $PBF_DATA --create-dirs -o /app/src/data.osm.pbf
 RUN service postgresql start && \
     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='nominatim'" | grep -q 1 || sudo -u postgres createuser -s nominatim && \
     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data && \


### PR DESCRIPTION
Some pbf files are located on different servers, a redirect is in place to lead you to the file.

The `-L` flag allows curl to follow this redirect.

Without the `-L` flag `/app/src/data.osm.pbf` will be corrupt (html instead of the expected data):
```
> curl http://download.geofabrik.de/europe/germany-latest.osm.pbf

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="http://ftp5.gwdg.de/pub/misc/openstreetmap/download.geofabrik.de/germany-latest.osm.pbf">here</a>.</p>
<hr>
<address>Apache/2.4.18 (Ubuntu) Server at download.geofabrik.de Port 80</address>
</body></html>
```


#### Curl manual
https://linux.die.net/man/1/curl
> -L/--location
(HTTP/HTTPS) If the server reports that the requested page has moved to a different location (indicated with a Location: header and a 3XX response code), this option will make curl redo the request on the new place. If used together with -i/--include or -I/--head, headers from all requested pages will be shown. When authentication is used, curl only sends its credentials to the initial host. If a redirect takes curl to a different host, it won't be able to intercept the user+password. See also --location-trusted on how to change this. You can limit the amount of redirects to follow by using the --max-redirs option.
When curl follows a redirect and the request is not a plain GET (for example POST or PUT), it will do the following request with a GET if the HTTP response was 301, 302, or 303. If the response code was any other 3xx code, curl will re-send the following request using the same unmodified method.