### PR TITLE
Reduce dependencies

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -8,14 +8,15 @@ RUN update-locale LANG=en_US.UTF-8
 
 # Install packages http://wiki.openstreetmap.org/wiki/Nominatim/Installation#Ubuntu.2FDebian
 RUN apt-get -y update --fix-missing && \
-    apt-get install -y build-essential libxml2-dev libpq-dev libbz2-dev libtool automake \
-    libproj-dev libboost-dev libboost-system-dev libboost-filesystem-dev \
-    libboost-thread-dev libexpat-dev gcc proj-bin libgeos-c1 libgeos++-dev \
-    libexpat-dev php5 php-pear php5-pgsql php5-json php-db libapache2-mod-php5 \
-    postgresql postgis postgresql-contrib postgresql-9.3-postgis-2.1 \
-    postgresql-server-dev-9.3 curl git autoconf-archive cmake python \
-    lua5.1 liblua5.1-dev libluabind-dev \
-    osmosis && \
+    apt-get install -o APT::Install-Recommends="false" -o APT::Install-Suggests="false" -y \
+        build-essential libxml2-dev libpq-dev libbz2-dev libtool automake \
+        libproj-dev libboost-dev libboost-system-dev libboost-filesystem-dev \
+        libboost-thread-dev libexpat-dev gcc proj-bin libgeos-c1 libgeos++-dev \
+        libexpat-dev php5 php-pear php5-pgsql php5-json php-db libapache2-mod-php5 \
+        postgresql postgis postgresql-contrib postgresql-9.3-postgis-2.1 \
+        postgresql-server-dev-9.3 curl git autoconf-archive cmake python \
+        lua5.1 liblua5.1-dev libluabind-dev \
+        osmosis && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* /var/tmp/*


### PR DESCRIPTION
Many packages available via apt-get have optional / suggested packages.
These are not always required / can be listed manually.

This will reduce the installed packages to ~500mb from ~700mb

Whats changed ?
The listed packages are still the same, suggested and recommended packages won't be installed:

`apt-get install -o APT::Install-Recommends="false" -o APT::Install-Suggests="false" -y`
