### PR TITLE
Upgrade nominatim to v2.5.1

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -27,7 +27,7 @@ RUN echo "host all  all    0.0.0.0/0  trust" >> /etc/postgresql/9.3/main/pg_hba.
     echo "listen_addresses='*'" >> /etc/postgresql/9.3/main/postgresql.conf
 
 # Nominatim install
-ENV NOMINATIM_VERSION v.2.5.0
+ENV NOMINATIM_VERSION v2.5.1
 RUN git clone --recursive git://github.com/twain47/Nominatim.git ./src
 RUN cd ./src && git checkout $NOMINATIM_VERSION && git submodule update --recursive --init && \
   ./autogen.sh && ./configure && make


### PR DESCRIPTION
While the monaco map worked perfectly with 2.5.0,
the German map didn't work with 2.5.0 (The queries "crashed").

Upgrading to 2.5.1 solved these crashes.

Tests didn't reveal any side effects