### PR TITLE
fixing links in README.md twain47 -> openstreetmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nominatim Docker
 
-100% working container for [Nominatim](https://github.com/twain47/Nominatim).
+100% working container for [Nominatim](https://github.com/openstreetmap/Nominatim).
 
 [![](https://images.microbadger.com/badges/image/mediagis/nominatim.svg)](https://microbadger.com/images/mediagis/nominatim "Get your own image badge on microbadger.com")
 
@@ -31,7 +31,7 @@ If a different country should be used you can set `PBF_DATA` on build.
   ENV PBF_DATA http://download.geofabrik.de/europe/monaco-latest.osm.pbf
   ```
 3. Configure incrimental update. By default CONST_Replication_Url configured for Monaco.
-If you want a different update source, you will need to declare `CONST_Replication_Url` in local.php. Documentation [here] (https://github.com/twain47/Nominatim/blob/master/docs/Import_and_update.md#updates). For example, to use the daily country extracts diffs for Gemany from geofabrik add the following:
+If you want a different update source, you will need to declare `CONST_Replication_Url` in local.php. Documentation [here] (https://github.com/openstreetmap/Nominatim/blob/master/docs/Import-and-Update.md#updates). For example, to use the daily country extracts diffs for Gemany from geofabrik add the following:
   ```
   @define('CONST_Replication_Url', 'http://download.geofabrik.de/europe/germany-updates');
   ```
@@ -59,7 +59,7 @@ Service will run on [http://localhost:8080/](http:/localhost:8080)
 
 # Update
 
-Full documentation for Nominatim update available [here](https://github.com/twain47/Nominatim/blob/master/docs/Import_and_update.md#updates). For a list of other methods see the output of:
+Full documentation for Nominatim update available [here](https://github.com/openstreetmap/Nominatim/blob/master/docs/Import-and-Update.md#updates). For a list of other methods see the output of:
   ```
   docker exec -it nominatim sudo -u nominatim ./src/utils/update.php --help
   ```
@@ -70,4 +70,4 @@ The following command will keep your database constantly up to date:
   ```
 If you have imported multiple country extracts and want to keep them
 up-to-date, have a look at the script in
-[issue #60](https://github.com/twain47/Nominatim/issues/60).
+[issue #60](https://github.com/openstreetmap/Nominatim/issues/60).


### PR DESCRIPTION
Links in README.md pointing to github.com/twain47 result in a 404 or are redirected to some github.com/openstreetmap
This PR fixes the (broken) Links.