### PR TITLE
making CONST_Replication_Url configurabel via --build-arg

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -34,7 +34,11 @@ RUN cd ./src && git checkout $NOMINATIM_VERSION && git submodule update --recurs
 
 
 # Nominatim create site
+ARG DYN_REP_URL="http://download.geofabrik.de/monaco-updates"
+RUN echo $DYN_REP_URL
 COPY local.php ./src/settings/local.php
+RUN sed -i "s|http://download.geofabrik.de/monaco-updates|$DYN_REP_URL|g" ./src/settings/local.php
+RUN cat ./src/settings/local.php
 RUN rm -rf /var/www/html/* && ./src/utils/setup.php --create-website /var/www/html
 
 # Apache configure

--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -35,10 +35,8 @@ RUN cd ./src && git checkout $NOMINATIM_VERSION && git submodule update --recurs
 
 # Nominatim create site
 ARG DYN_REP_URL="http://download.geofabrik.de/monaco-updates"
-RUN echo $DYN_REP_URL
 COPY local.php ./src/settings/local.php
 RUN sed -i "s|http://download.geofabrik.de/monaco-updates|$DYN_REP_URL|g" ./src/settings/local.php
-RUN cat ./src/settings/local.php
 RUN rm -rf /var/www/html/* && ./src/utils/setup.php --create-website /var/www/html
 
 # Apache configure

--- a/README.md
+++ b/README.md
@@ -35,12 +35,18 @@ If you want a different update source, you will need to declare `CONST_Replicati
   ```
   @define('CONST_Replication_Url', 'http://download.geofabrik.de/europe/germany-updates');
   ```
+  Alternatively you could set a different CONST_Replication_Url on build tim by setting DYN_REPL_URL as build-arg. See "Build".
 
-4. Build 
+4. Build
 
   ```
   docker build -t nominatim .
   ```
+
+  with build-arg:
+  ```
+   docker build --build-arg DYN_REP_URL=http://download.geofabrik.de/europe/germany-updates PBF_DATA=http://download.geofabrik.de/europe/germany-latest.osm.pbf -t nominatim .
+   ```
 5. Run
 
   ```


### PR DESCRIPTION
This PR makes the CONST_Replication_Url in local.php configurable in Docker build stage by setting --build-arg DYN_REPL_URL=http://example.com/foo-updates. This makes it easier to build a Nominatim Container based on a specific Geofabrik area without having to change Git tracked files.
If DYN_REPL_URL is not set by --build-arg the default Url will be substituted by the same string - which results in no change.