### PR TITLE
Cancel build if curl receives error code

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -42,7 +42,7 @@ COPY nominatim.conf /etc/apache2/sites-enabled/000-default.conf
 
 # Load initial data
 ARG PBF_DATA=http://download.geofabrik.de/europe/monaco-latest.osm.pbf
-RUN curl -L $PBF_DATA --create-dirs -o /app/src/data.osm.pbf
+RUN curl -L -f $PBF_DATA --create-dirs -o /app/src/data.osm.pbf
 RUN service postgresql start && \
     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='nominatim'" | grep -q 1 || sudo -u postgres createuser -s nominatim && \
     sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data && \


### PR DESCRIPTION
Similar to #11 this PR improves curl integration in the Dockerfile.

The effect in action:
```
Step 17/22 : RUN curl --fail -L $PBF_DATA --create-dirs -o /app/src/data.osm.pbf
 ---> Running in d710e6d3b4d9
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
The command '/bin/sh -c curl --fail -L $PBF_DATA --create-dirs -o /app/src/data.osm.pbf' returned a non-zero code: 22
```

from the [curl manual](https://linux.die.net/man/1/curl): 
> -f/--fail
(HTTP) Fail silently (no output at all) on server errors. This is mostly done to better enable scripts etc to better deal with failed attempts. In normal cases when a HTTP server fails to deliver a document, it returns an HTML document stating so (which often also describes why and more). This flag will prevent curl from outputting that and return error 22.
This method is not fail-safe and there are occasions where non-successful response codes will slip through, especially when authentication is involved (response codes 401 and 407).

What happens if curl downloads an error page instead (without this fix):
```
Reading in file: /app/src/data.osm.pbf
Using PBF parser.
node cache: stored: 0(-nan%), storage efficiency: -nan% (dense blocks: 0, sparse nodes: 0), hit rate: -nan%
Osm2pgsql failed due to ERROR: PBF error: invalid BlobHeader size (> max_blob_header_size)
ERROR: Error executing external command: /app/src/osm2pgsql/osm2pgsql -lsc -O gazetteer --hstore --number-processes 1 -C 1207 -P 5432 -d nominatim /app/src/data.osm.pbf
```