### PR TITLE
3.0 include pyosmium to run continuous updates

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -y update -qq && \
     postgresql-server-dev-9.5 postgresql-9.5-postgis-2.2 postgresql-contrib-9.5 \
     apache2 php php-pgsql libapache2-mod-php php-pear php-db \
     php-intl git curl sudo \
+    python-pip libboost-python-dev \
     osmosis && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
@@ -30,6 +31,9 @@ ENV NOMINATIM_VERSION v3.0.1
 RUN git clone --recursive https://github.com/openstreetmap/Nominatim ./src
 RUN cd ./src && git checkout tags/$NOMINATIM_VERSION && git submodule update --recursive --init && \
     mkdir build && cd build && cmake .. && make
+
+# Osmium install to run continuous updates
+RUN pip install osmium
 
 # Apache configure
 COPY local.php /app/src/build/settings/local.php

--- a/3.0/local.php
+++ b/3.0/local.php
@@ -4,8 +4,9 @@
  @define('CONST_Postgis_Version', '2.2');
  // Website settings
  @define('CONST_Website_BaseURL', '/');
- @define('CONST_Replication_Url', 'http://download.geofabrik.de/monaco-updates');
+ @define('CONST_Replication_Url', 'http://download.geofabrik.de/europe/monaco-updates');
  @define('CONST_Replication_MaxInterval', '86400');     // Process each update separately, osmosis cannot merge multiple updates
  @define('CONST_Replication_Update_Interval', '86400');  // How often upstream publishes diffs
  @define('CONST_Replication_Recheck_Interval', '900');   // How long to sleep if no update found yet
+ @define('CONST_Pyosmium_Binary', '/usr/local/bin/pyosmium-get-changes');
 ?>

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Service will run on [http://localhost:8080/](http:/localhost:8080)
 
 Full documentation for Nominatim update available [here](https://github.com/openstreetmap/Nominatim/blob/master/docs/Import-and-Update.md#updates). For a list of other methods see the output of:
   ```
-  docker exec -it nominatim sudo -u nominatim ./src/utils/update.php --help
+  docker exec -it nominatim sudo -u nominatim ./src/build/utils/update.php --help
   ```
 
 The following command will keep your database constantly up to date:
   ```
-  docker exec -it nominatim sudo -u nominatim ./src/utils/update.php --import-osmosis-all --no-npi
+  docker exec -it nominatim sudo -u nominatim ./src/build/utils/update.php --import-osmosis-all
   ```
 If you have imported multiple country extracts and want to keep them
 up-to-date, have a look at the script in


### PR DESCRIPTION
Nominatim 3.0  [requires](https://github.com/openstreetmap/Nominatim/blob/master/docs/Installation.md#software) pyosmium installed to run continuous updates. Using pip - and not apt - for installation is [recommended](https://github.com/openstreetmap/Nominatim/blob/master/docs/Import-and-Update.md#installing-the-newest-version-of-pyosmium).

Also, the execution path of the update script changed in 3.0 so I updated the readme.