### PR TITLE
Add trap handler shutting down previously started services

### DIFF
--- a/3.1/README.md
+++ b/3.1/README.md
@@ -18,7 +18,7 @@
 4. After the import is finished the /home/me/nominatimdata/postgresdata folder will contain the full postgress binaries of
    a postgis/nominatim database. The easiest way to start the nominatim as a single node is the following:
    ```
-   docker run --restart=always -p 6432:5432 -p 7070:8080 -d -v /home/me/nominatimdata/postgresdata:/var/lib/postgresql/9.5/main nominatim sh /app/start.sh
+   docker run --restart=always -p 6432:5432 -p 7070:8080 -d -v /home/me/nominatimdata/postgresdata:/var/lib/postgresql/9.5/main nominatim bash /app/start.sh
    ```
 
 5. Advanced configuration. If necessary you can split the osm installation into a database and restservice layer

--- a/3.1/start.sh
+++ b/3.1/start.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+
+stopServices() {
+        service apache2 stop
+        service postgresql stop
+}
+trap stopServices TERM
+
 service postgresql start
-/usr/sbin/apache2ctl -D FOREGROUND
-tail -f /var/log/postgresql/postgresql-9.5-main.log
+service apache2 start
+
+# fork a process and wait for it
+tail -f /var/log/postgresql/postgresql-9.5-main.log &
+wait


### PR DESCRIPTION
This pull request adds handlers shutting down postgresql and apache2 when the start.sh script is stopped.

This became necessary after we realized, that docker stops the container after the 10 seconds timeout is elapsed. Furthermore the hard killing of apache2 resulted in a dangling apache2.pid file preventing restarts of the same container instance.