### PR TITLE
Use a required connection string style in new Postgres

### DIFF
--- a/3.3/local.php
+++ b/3.3/local.php
@@ -10,6 +10,5 @@
  @define('CONST_Replication_Recheck_Interval', '900');   // How long to sleep if no update found yet
  @define('CONST_Pyosmium_Binary', '/usr/local/bin/pyosmium-get-changes');
 
- //@define('CONST_Database_DSN', 'pgsql://nominatim:password1234@192.168.1.128:6432/nominatim'); // <driver>://<username>:<password>@<host>:<port>/<database>
-
+ //@define('CONST_Database_DSN', 'pgsql:host=192.168.1.128;port=6432;user=nominatim;password=password1234;dbname=nominatim'); <driver>:host=<host>;port=<port>;user=<username>;password=<password>;dbname=<database>
 ?>


### PR DESCRIPTION
Without this change, Nominatim is not able to connect to the Postgres instance. It throws an error "missing = after (...)".

Reference:
https://github.com/openstreetmap/Nominatim/blob/master/settings/defaults.php
