### PR TITLE
Use Python 3 for Nominatim supplied scripts

### DIFF
--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -40,6 +40,8 @@ COPY nominatim.conf /etc/apache2/sites-enabled/000-default.conf
 
 # Load initial data
 RUN curl http://www.nominatim.org/data/country_grid.sql.gz > /app/src/data/country_osm_grid.sql.gz
+RUN sed -i -e 's|bin/python|bin/python3|' /app/src/utils/*.py
+RUN chmod o=rwx /app/src/build
 
 EXPOSE 5432
 EXPOSE 8080


### PR DESCRIPTION
As it is right now, the updates doesn't work (at least for version 3.3) because:
- Nominatim scripts use /usr/bin/python, though osmium lib is installed for python 3;
- Update process runs as a postgres user and it needs a write permission to /app/src/build.