### PR TITLE
Init.sh : Reinitialize won't block

### DIFF
--- a/3.4/init.sh
+++ b/3.4/init.sh
@@ -2,6 +2,7 @@ OSMFILE=$1
 PGDIR=$2
 THREADS=$3
 
+rm -rf /data/$PGDIR && \
 mkdir -p /data/$PGDIR && \
 
 chown postgres:postgres /data/$PGDIR && \


### PR DESCRIPTION
Reinitializing the osm database won't block anymore when the data is already present. Prevents having to rebuild the image in case you want to change the initialization (changing osm file for example=