### PR TITLE
Add cache to the database initialization

### DIFF
--- a/3.4/init.sh
+++ b/3.4/init.sh
@@ -14,6 +14,6 @@ sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-d
 sudo -u postgres psql postgres -c "DROP DATABASE IF EXISTS nominatim" && \
 useradd -m -p password1234 nominatim && \
 chown -R nominatim:nominatim ./src && \
-sudo -u nominatim ./src/build/utils/setup.php --osm-file $OSMFILE --all --threads $THREADS && \
+sudo -u nominatim ./src/build/utils/setup.php --osm-file $OSMFILE --all --threads $THREADS  --osm2pgsql-cache 1024 2>&1 && \
 sudo -u postgres /usr/lib/postgresql/11/bin/pg_ctl -D /data/$PGDIR stop && \
 sudo chown -R postgres:postgres /data/$PGDIR


### PR DESCRIPTION
Prevents Out Of Memory Exception by adding 1GB cache for osm2pgsql. You can also add --memory="Xg" --memory-swap="(X+Y)g" to the run parameters where X is the number of Gigabyte of RAM you can allocate to docker and Y the number of Gigabyte of swap. For example : --memory="8g" --memory-swap="12g"