### PR TITLE
add Nominatim Release 3.5

### DIFF
--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
+
+RUN apt-get -y update -qq && \
+    apt-get -y install locales && \
+    locale-gen en_US.UTF-8 && \
+    update-locale LANG=en_US.UTF-8 && \
+    apt-get install -o APT::Install-Recommends="false" -o APT::Install-Suggests="false" -y \
+    build-essential cmake g++ libboost-dev libboost-system-dev \
+    libboost-filesystem-dev libexpat1-dev zlib1g-dev \
+    libbz2-dev libpq-dev libproj-dev \
+    postgresql-server-dev-12 postgresql-12-postgis-3 \
+    postgresql-contrib postgresql-12-postgis-3-scripts \
+    apache2 php php-pgsql libapache2-mod-php \
+    php-intl python3-setuptools python3-dev python3-pip \
+    python3-psycopg2 python3-tidylib git curl sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* /var/tmp/*
+
+WORKDIR /app
+
+# Configure postgres
+RUN echo "host all  all    0.0.0.0/0  trust" >> /etc/postgresql/12/main/pg_hba.conf && \
+    echo "listen_addresses='*'" >> /etc/postgresql/12/main/postgresql.conf
+
+# Osmium install to run continuous updates
+RUN pip3 install osmium
+
+# Nominatim install
+ENV NOMINATIM_VERSION v3.5.0
+RUN git clone --recursive https://github.com/openstreetmap/Nominatim ./src
+RUN cd ./src && git checkout tags/$NOMINATIM_VERSION && git submodule update --recursive --init && \
+    mkdir build && cd build && cmake .. && make
+
+# Apache configure
+COPY local.php /app/src/build/settings/local.php
+COPY nominatim.conf /etc/apache2/sites-enabled/000-default.conf
+
+# Load initial data
+RUN curl http://www.nominatim.org/data/country_grid.sql.gz > /app/src/data/country_osm_grid.sql.gz
+RUN chmod o=rwx /app/src/build
+
+EXPOSE 5432
+EXPOSE 8080
+
+COPY start.sh /app/start.sh
+COPY startapache.sh /app/startapache.sh
+COPY startpostgres.sh /app/startpostgres.sh
+COPY init.sh /app/init.sh
+
+

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -1,0 +1,77 @@
+# Nominatim Docker (Nominatim version 3.5)
+
+1. Build
+  ```
+  docker build --pull --rm -t nominatim .
+  ```
+2. Copy <your_country>.osm.pbf to a local directory (i.e. /home/me/nominatimdata)
+
+3. Initialize Nominatim Database
+  ```
+  docker run -t -v /home/me/nominatimdata:/data nominatim  sh /app/init.sh /data/<your_country>.osm.pbf postgresdata 4
+  ```
+  Where 4 is the number of threads to use during import. In general the import of data in postgres is a very time consuming
+  process that may take hours or days. If you run this process on a multiprocessor system make sure that it makes the best use
+  of it. You can delete the /home/me/nominatimdata/<your_country>.osm.pbf once the import is finished.
+
+
+4. After the import is finished the /home/me/nominatimdata/postgresdata folder will contain the full postgress binaries of
+   a postgis/nominatim database. The easiest way to start the nominatim as a single node is the following:
+   ```
+   docker run --restart=always -p 6432:5432 -p 7070:8080 -d --name nominatim -v /home/me/nominatimdata/postgresdata:/var/lib/postgresql/12/main nominatim bash /app/start.sh
+   ```
+
+5. Advanced configuration. If necessary you can split the osm installation into a database and restservice layer
+
+   In order to set the  nominatib-db only node:
+
+   ```
+   docker run --restart=always -p 6432:5432 -d -v /home/me/nominatimdata/postgresdata:/var/lib/postgresql/12/main nominatim sh /app/startpostgres.sh
+   ```
+   After doing this create the /home/me/nominatimdata/conf folder and copy there the docker/local.php file. Then uncomment the following line:
+
+   ```
+   @define('CONST_Database_DSN', 'pgsql://nominatim:password1234@192.168.1.128:6432/nominatim'); // <driver>://<username>:<password>@<host>:<port>/<database>
+   ```
+
+   You can start the  nominatib-rest only node with the following command:
+
+   ```
+   docker run --restart=always -p 7070:8080 -d -v /home/me/nominatimdata/conf:/data nominatim sh /app/startapache.sh
+   ```
+
+6. Configure incremental update. By default CONST_Replication_Url configured for Monaco.
+If you want a different update source, you will need to declare `CONST_Replication_Url` in local.php. Documentation [here] (https://github.com/openstreetmap/Nominatim/blob/master/docs/admin/Import-and-Update.md#updates). For example, to use the daily country extracts diffs for Gemany from geofabrik add the following:
+  ```
+  @define('CONST_Replication_Url', 'http://download.geofabrik.de/europe/germany-updates');
+  ```
+
+  Now you will have a fully functioning nominatim instance available at : [http://localhost:7070/](http://localhost:7070). Unlike the previous versions
+  this one does not store data in the docker context and this results to a much slimmer docker image.
+
+
+# Update
+
+Full documentation for Nominatim update available [here](https://github.com/openstreetmap/Nominatim/blob/master/docs/admin/Import-and-Update.md#updates). For a list of other methods see the output of:
+  ```
+  docker exec -it nominatim sudo -u postgres ./src/build/utils/update.php --help
+  ```
+
+To initialise the updates run
+  ```
+  docker exec -it nominatim sudo -u postgres ./src/build/utils/update.php --init-updates
+  ```
+
+The following command will keep your database constantly up to date:
+  ```
+  docker exec -it nominatim sudo -u postgres ./src/build/utils/update.php --import-osmosis-all
+  ```
+If you have imported multiple country extracts and want to keep them
+up-to-date, have a look at the script in
+[issue #60](https://github.com/openstreetmap/Nominatim/issues/60).
+
+# Docker image upgrade to 3.5
+
+With 3.5 we have switched to Ubuntu 20.04 (LTS) which uses PostgreSQL 12. If you want to reuse your old data dictionary without importing the data again you have to make sure to migrate the data from PostgreSQL 11 to 12 with a command like ```pg_upgrade``` (see: [https://www.postgresql.org/docs/current/pgupgrade.html](https://www.postgresql.org/docs/current/pgupgrade.html)). 
+
+You can try a script like [https://github.com/tianon/docker-postgres-upgrade](https://github.com/tianon/docker-postgres-upgrade) with some modifications.

--- a/3.5/init.sh
+++ b/3.5/init.sh
@@ -1,0 +1,21 @@
+OSMFILE=$1
+PGDIR=$2
+THREADS=$3
+
+rm -rf /data/$PGDIR && \
+mkdir -p /data/$PGDIR && \
+
+chown postgres:postgres /data/$PGDIR && \
+
+export  PGDATA=/data/$PGDIR  && \
+sudo -u postgres /usr/lib/postgresql/12/bin/initdb -D /data/$PGDIR && \
+sudo -u postgres /usr/lib/postgresql/12/bin/pg_ctl -D /data/$PGDIR start && \
+sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='nominatim'" | grep -q 1 || sudo -u postgres createuser -s nominatim && \
+sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data && \
+sudo -u postgres psql postgres -c "DROP DATABASE IF EXISTS nominatim" && \
+useradd -m -p password1234 nominatim && \
+chown -R nominatim:nominatim ./src && \
+sudo -u nominatim ./src/build/utils/setup.php --osm-file $OSMFILE --all --threads $THREADS && \
+sudo -u nominatim ./src/build/utils/check_import_finished.php && \
+sudo -u postgres /usr/lib/postgresql/12/bin/pg_ctl -D /data/$PGDIR stop && \
+sudo chown -R postgres:postgres /data/$PGDIR

--- a/3.5/local.php
+++ b/3.5/local.php
@@ -1,0 +1,12 @@
+<?php
+ // Paths
+ @define('CONST_Postgresql_Version', '12');
+ @define('CONST_Postgis_Version', '3');
+ // Website settings
+ @define('CONST_Website_BaseURL', '/');
+ @define('CONST_Replication_Url', 'http://download.geofabrik.de/europe/monaco-updates');
+ @define('CONST_Replication_MaxInterval', '86400');     // Process each update separately, osmosis cannot merge multiple updates
+ @define('CONST_Replication_Update_Interval', '86400');  // How often upstream publishes diffs
+ @define('CONST_Replication_Recheck_Interval', '900');   // How long to sleep if no update found yet
+ @define('CONST_Pyosmium_Binary', '/usr/local/bin/pyosmium-get-changes');
+ //@define('CONST_Database_DSN', 'pgsql:host=192.168.1.128;port=6432;user=nominatim;password=password1234;dbname=nominatim'); <driver>:host=<host>;port=<port>;user=<username>;password=<password>;dbname=<database>

--- a/3.5/nominatim.conf
+++ b/3.5/nominatim.conf
@@ -1,0 +1,13 @@
+Listen 8080
+<VirtualHost *:8080>
+        DocumentRoot /app/src/build/website
+        CustomLog /var/log/apache2/access.log combined
+        ErrorLog /var/log/apache2/error.log
+        LogLevel debug
+        <Directory /app/src/build/website>
+                Options FollowSymLinks MultiViews
+                DirectoryIndex search.php
+                Require all granted
+        </Directory>
+        AddType text/html .php
+</VirtualHost>

--- a/3.5/start.sh
+++ b/3.5/start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+stopServices() {
+        service apache2 stop
+        service postgresql stop
+}
+trap stopServices TERM
+
+service postgresql start
+service apache2 start
+
+# fork a process and wait for it
+tail -f /var/log/postgresql/postgresql-12-main.log &
+wait

--- a/3.5/startapache.sh
+++ b/3.5/startapache.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cp /data/local.php /app/src/build/settings/local.php
+
+/usr/sbin/apache2ctl -D FOREGROUND
+tail -f /var/log/apache2/error.log
+

--- a/3.5/startpostgres.sh
+++ b/3.5/startpostgres.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+service postgresql start
+tail -f /var/log/postgresql/postgresql-12-main.log

--- a/README.md
+++ b/README.md
@@ -6,29 +6,32 @@
 [![](https://images.microbadger.com/badges/image/mediagis/nominatim.svg)](https://microbadger.com/images/mediagis/nominatim "Get your own image badge on microbadger.com")
 # Supported tags and respective `Dockerfile` links #
 
+- [`3.5.0`, `3.5`  (*3.5/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.5)
 - [`3.4.2`, `3.4`  (*3.4/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.4)
 - [`3.3.1`, `3.3`  (*3.3/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.3)
 - [`3.2.1`, `3.2`  (*3.2/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.2)
 - [`3.1.0`, `3.1`  (*3.1/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.1)
 - [`3.0.1`, `3.0`  (*3.0/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.0)
-- [`2.5.1`, `2.5`, `latest`  (*2.5/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/2.5)
+- [`2.5.1`, `2.5`  (*2.5/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/2.5)
 
-Run [http://wiki.openstreetmap.org/wiki/Nominatim](http://wiki.openstreetmap.org/wiki/Nominatim) in a docker container. Clones the current master and builds it. This is always the latest version, be cautious as it may be unstable.
+Run [http://wiki.openstreetmap.org/wiki/Nominatim](http://wiki.openstreetmap.org/wiki/Nominatim) in a docker container. Clones the tagged release and builds it. 
 
-Uses Ubuntu 19.10 and PostgreSQL 11.3
+**Caution:** When you upgrade to another version (e.g. 3.4 to 3.5) there may be major version changes like Postgres and data incompatiblity. See the relevant instructions for each version. Also check the Nominatim migration guide [https://www.nominatim.org/release-docs/latest/admin/Migration/](https://www.nominatim.org/release-docs/latest/admin/Migration/).
 
-# Country
+The latest version uses Ubuntu 20.04 and PostgreSQL 12.
+
 To check that everything is set up correctly, download and load to Postgres PBF file with minimal size - Europe/Monacco (latest) from geofabrik.de.
 
 If a different country should be used you can set `PBF_DATA` on build.
 
-1. Clone repository
+# How to use
+Clone repository
 
   ```
   # git clone git@github.com:mediagis/nominatim-docker.git
   # cd nominatim-docker/<version>
   ```
-See relevant installation instructions for each version
+See relevant installation instructions for each version in the <version>/README.md
 
 ## Contributors
 


### PR DESCRIPTION
- added Nominatim 3.5 (see: https://github.com/osm-search/Nominatim/releases/tag/v3.5.0)
- switched to Ubuntu 20.04 (since its an LTS and there is a official installation guide in the Nominatim docs for 20.04)
- integrated https://github.com/mediagis/nominatim-docker/pull/103
- integrated https://github.com/mediagis/nominatim-docker/pull/74

To-Do:

- we should provide a description / example how to migrate the PostgreSQL 11 data to version 12 to help user with the migration, feedback & help appreciated

Works pretty well with a fresh import but right now you can't reuse your already imported that when migration from a docker image <= 3.4.