### PR TITLE
fixed 3.1 'RuntimeError: Python 3.3 or larger required' docker build …

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -34,7 +34,7 @@ RUN cd ./src && git checkout tags/$NOMINATIM_VERSION && git submodule update --r
     mkdir build && cd build && cmake .. && make
 
 # Osmium install to run continuous updates
-RUN pip install osmium
+RUN pip install osmium==2.15.4
 
 # Apache configure
 COPY local.php /app/src/build/settings/local.php


### PR DESCRIPTION
Fixed following error in docker build for version 3.1:

```
Step 11/20 : RUN pip install osmium
 ---> Running in 6a27b3f76464

Collecting osmium
  Downloading https://files.pythonhosted.org/packages/0e/40/244d50761ab3f1d01f5822748cb4a3e48a63184f198dc33f3de89ba98d08/osmium-3.0.0.tar.gz (2.2MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-9AiH_t/osmium/setup.py", line 116, in <module>
        raise RuntimeError("Python 3.3 or larger required.")
    RuntimeError: Python 3.3 or larger required.
```