### PR TITLE
Dockerfile: Add build options for including US and/or UK postcode data

### DIFF
--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -40,6 +40,10 @@ COPY local.php /app/src/build/settings/local.php
 COPY nominatim.conf /etc/apache2/sites-enabled/000-default.conf
 
 # Load initial data
+ARG with_postcodes_gb
+ARG with_postcodes_us
+RUN if [ "$with_postcodes_gb" = "" ]; then echo "Skipping optional GB postcode file"; else echo "Downloading optional GB postcode file"; curl http://www.nominatim.org/data/gb_postcode_data.sql.gz > /app/src/data/gb_postcode_data.sql.gz; fi;
+RUN if [ "$with_postcodes_us" = "" ]; then echo "Skipping optional US postcode file"; else echo "Downloading optional US postcode file"; curl http://www.nominatim.org/data/us_postcode_data.sql.gz > /app/src/data/us_postcode_data.sql.gz; fi;
 RUN curl http://www.nominatim.org/data/country_grid.sql.gz > /app/src/data/country_osm_grid.sql.gz
 RUN chmod o=rwx /app/src/build
 

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -4,6 +4,8 @@
   ```
   docker build --pull --rm -t nominatim .
   ```
+  See below for optional build arguments to include postcode data in your image.
+
 2. Copy <your_country>.osm.pbf to a local directory (i.e. /home/me/nominatimdata)
 
 3. Initialize Nominatim Database
@@ -49,6 +51,14 @@ If you want a different update source, you will need to declare `CONST_Replicati
   Now you will have a fully functioning nominatim instance available at : [http://localhost:7070/](http://localhost:7070). Unlike the previous versions
   this one does not store data in the docker context and this results to a much slimmer docker image.
 
+# Postcodes
+
+Nominatim requires additional data files to accurately assign postcodes data in the US and Great Britain (Northern Ireland postcodes are not included in this file) as described in [these Nominatim docs](https://nominatim.org/release-docs/latest/admin/Import-and-Update/#downloading-additional-data). Without this data, you may get incorrect postcodes for some address lookups.
+
+These data files aren't downloaded by default, but you can add them with additional arguments at the build stage. To include the US postcode data file, add "--build-arg with_postcodes_us=1" to the command line in stage 1, above. To include GB postcodes, run with "--build-arg with_postcodes_gb=1". You can run with both at once if desired, eg:
+  ```
+  docker build --pull --rm -t nominatim --build-arg with_postcodes_us=1 --build-arg with_postcodes_gb=1 .
+  ```
 
 # Update
 


### PR DESCRIPTION
As discussed in https://github.com/mediagis/nominatim-docker/issues/140, you need to include the additional files to get accurate postcode data for the UK/US. I can see this shouldn't be done by default, so I added a pair of build args to the Dockerfile to optionally include them in the image.

Run with "--build-arg with_postcodes_us=1" and/or "--build-arg with_postcodes_gb=1" to download optional postcode data files for more accurate postcode attribution in those areas.