### PR TITLE
upgrade to 3.5.2

### DIFF
--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -30,7 +30,7 @@ RUN echo "host all  all    0.0.0.0/0  trust" >> /etc/postgresql/12/main/pg_hba.c
 RUN pip3 install osmium
 
 # Nominatim install
-ENV NOMINATIM_VERSION v3.5.1
+ENV NOMINATIM_VERSION v3.5.2
 RUN git clone --recursive https://github.com/openstreetmap/Nominatim ./src
 RUN cd ./src && git checkout tags/$NOMINATIM_VERSION && git submodule update --recursive --init && \
     mkdir build && cd build && cmake .. && make -j`nproc`

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -80,6 +80,16 @@ If you have imported multiple country extracts and want to keep them
 up-to-date, have a look at the script in
 [issue #60](https://github.com/openstreetmap/Nominatim/issues/60).
 
+# Upgrade Guide for 3.5.x
+
+## Upgrade to 3.5.2
+
+As referenced in the Nominatim release ([https://github.com/osm-search/Nominatim/releases/tag/v3.5.2](https://github.com/osm-search/Nominatim/releases/tag/v3.5.2)) you need to make sure to run the following command after the upgrade: 
+
+```
+docker exec -it nominatim sudo -u postgres ./src/build/utils/setup.php --create-functions --enable-diff-updates
+```
+
 # Docker image upgrade to 3.5
 
 With 3.5 we have switched to Ubuntu 20.04 (LTS) which uses PostgreSQL 12. If you want to reuse your old data dictionary without importing the data again you have to make sure to migrate the data from PostgreSQL 11 to 12 with a command like ```pg_upgrade``` (see: [https://www.postgresql.org/docs/current/pgupgrade.html](https://www.postgresql.org/docs/current/pgupgrade.html)). 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![](https://images.microbadger.com/badges/image/mediagis/nominatim.svg)](https://microbadger.com/images/mediagis/nominatim "Get your own image badge on microbadger.com")
 # Supported tags and respective `Dockerfile` links #
 
-- [`3.5.1`, `3.5`  (*3.5/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.5)
+- [`3.5.2`, `3.5`  (*3.5/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.5)
 - [`3.4.2`, `3.4`  (*3.4/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.4)
 - [`3.3.1`, `3.3`  (*3.3/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.3)
 - [`3.2.1`, `3.2`  (*3.2/Dockerfile*)](https://github.com/mediagis/nominatim-docker/tree/master/3.2)


### PR DESCRIPTION
Nominatim Release 3.5.2: https://github.com/osm-search/Nominatim/releases/tag/v3.5.2