### PR TITLE
Move import speed up overrides to separate file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,14 @@ jobs:
           ./assert-non-empty-json "http://localhost:8081/search.php?q=avenue%20pasteur"
 
       - name: Login to DockerHub
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'mediagis' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push docker image to Dockerhub
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'mediagis' }}
         run: |
           # we tag the image with the version number of nominatim but also
           # a second tag which adds the git commit ID so that you can refer

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -79,10 +79,6 @@ RUN true \
     && make -j`nproc` \
     && chmod o=rwx .
 
-# Apache configure.
-COPY local.php /app/src/build/settings/local.php
-COPY nominatim.conf /etc/apache2/sites-enabled/000-default.conf
-
 RUN curl http://www.nominatim.org/data/country_grid.sql.gz > /app/src/data/country_osm_grid.sql.gz
 
 RUN true \
@@ -108,6 +104,13 @@ RUN true \
         /root/.cache \
         /app/src/.git \
         /var/lib/apt/lists/*
+
+# Apache configuration
+COPY local.php /app/src/build/settings/local.php
+COPY nominatim.conf /etc/apache2/sites-enabled/000-default.conf
+
+# Postgres config overrides to improve import performance (but reduce crash recovery safety)
+COPY postgresql.auto.conf /etc/postgresql/12/main/
 
 COPY init.sh /app/init.sh
 COPY start.sh /app/start.sh

--- a/3.6/init.sh
+++ b/3.6/init.sh
@@ -33,10 +33,6 @@ if [ ! -f /var/lib/postgresql/12/main/PG_VERSION ]; then
   sudo -u postgres /usr/lib/postgresql/12/bin/initdb -D /var/lib/postgresql/12/main
 fi
 
-# Update postgres config to improve import performance
-sed -i "s/fsync = on/fsync = off/g" /etc/postgresql/12/main/postgresql.conf
-sed -i "s/full_page_writes = on/full_page_writes = off/g" /etc/postgresql/12/main/postgresql.conf
-
 sudo service postgresql start && \
 sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='nominatim'" | grep -q 1 || sudo -u postgres createuser -s nominatim && \
 sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data && \
@@ -52,8 +48,8 @@ sudo -u nominatim ./src/build/utils/update.php --init-updates
 
 sudo service postgresql stop
 
-sed -i "s/fsync = off/fsync = on/g" /etc/postgresql/12/main/postgresql.conf
-sed -i "s/full_page_writes = off/full_page_writes = on/g" /etc/postgresql/12/main/postgresql.conf
+# Remove slightly unsafe postgres config overrides that made the import faster
+rm /etc/postgresql/12/main/postgresql.auto.conf
 
 echo "Deleting downloaded dumps in ${DATA_DIR}"
 rm ${DATA_DIR}/*sql.gz ${OSMFILE}

--- a/3.6/postgresql.auto.conf
+++ b/3.6/postgresql.auto.conf
@@ -1,0 +1,2 @@
+fsync = off
+full_page_writes = off


### PR DESCRIPTION
@mtmail has pointed out that the import speed up postgres overrides are probably not working.

I found out that there is a better way to do it https://www.postgresql.org/docs/12/config-setting.html

That's implemented in this PR.