### PR TITLE
Fix maintenance typo

### DIFF
--- a/3.6/README.md
+++ b/3.6/README.md
@@ -33,7 +33,7 @@ The following environment variables are available for configuration:
 The following environment variables are available to tune PostgreSQL:
 
   - `POSTGRES_SHARED_BUFFERS` (default: `2GB`)
-  - `POSTGRES_MAINTAINENCE_WORK_MEM` (default: `10GB`)
+  - `POSTGRES_MAINTENANCE_WORK_MEM` (default: `10GB`)
   - `POSTGRES_AUTOVACUUM_WORK_MEM` (default: `2GB`)
   - `POSTGRES_WORK_MEM` (default: `50MB`)
   - `POSTGRES_EFFECTIVE_CACHE_SIZE` (default: `24GB`)

--- a/3.6/config.sh
+++ b/3.6/config.sh
@@ -12,7 +12,7 @@ else
     sed -i "s|__REPLICATION_URL__|$REPLICATION_URL|g" /app/src/build/settings/local.php
 fi
 
-# PostgresSQL Tuning
+# PostgreSQL Tuning
 
 if [ ! -z "$POSTGRES_SHARED_BUFFERS" ]; then sed -i "s/shared_buffers = 2GB/shared_buffers = $POSTGRES_SHARED_BUFFERS/g" /etc/postgresql/12/main/conf.d/postgres-tuning.conf; fi
 if [ ! -z "$POSTGRES_MAINTENANCE_WORK_MEM" ]; then sed -i "s/maintenance_work_mem = 10GB/maintenance_work_mem = $POSTGRES_MAINTENANCE_WORK_MEM/g" /etc/postgresql/12/main/conf.d/postgres-tuning.conf; fi

--- a/3.6/config.sh
+++ b/3.6/config.sh
@@ -15,7 +15,7 @@ fi
 # PostgresSQL Tuning
 
 if [ ! -z "$POSTGRES_SHARED_BUFFERS" ]; then sed -i "s/shared_buffers = 2GB/shared_buffers = $POSTGRES_SHARED_BUFFERS/g" /etc/postgresql/12/main/conf.d/postgres-tuning.conf; fi
-if [ ! -z "$POSTGRES_MAINTAINENCE_WORK_MEM" ]; then sed -i "s/maintenance_work_mem = 10GB/maintenance_work_mem = $POSTGRES_MAINTAINENCE_WORK_MEM/g" /etc/postgresql/12/main/conf.d/postgres-tuning.conf; fi
+if [ ! -z "$POSTGRES_MAINTENANCE_WORK_MEM" ]; then sed -i "s/maintenance_work_mem = 10GB/maintenance_work_mem = $POSTGRES_MAINTENANCE_WORK_MEM/g" /etc/postgresql/12/main/conf.d/postgres-tuning.conf; fi
 if [ ! -z "$POSTGRES_AUTOVACUUM_WORK_MEM" ]; then sed -i "s/autovacuum_work_mem = 2GB/autovacuum_work_mem = $POSTGRES_AUTOVACUUM_WORK_MEM/g" /etc/postgresql/12/main/conf.d/postgres-tuning.conf; fi
 if [ ! -z "$POSTGRES_WORK_MEM" ]; then sed -i "s/work_mem = 50MB/work_mem = $POSTGRES_WORK_MEM/g" /etc/postgresql/12/main/conf.d/postgres-tuning.conf; fi
 if [ ! -z "$POSTGRES_EFFECTIVE_CACHE_SIZE" ]; then sed -i "s/effective_cache_size = 24GB/effective_cache_size = $POSTGRES_EFFECTIVE_CACHE_SIZE/g" /etc/postgresql/12/main/conf.d/postgres-tuning.conf; fi


### PR DESCRIPTION
Change a small typo in variable name in 3.6