### PR TITLE
enable logrotate for apache2

### DIFF
--- a/3.5/nominatim.conf
+++ b/3.5/nominatim.conf
@@ -1,13 +1,13 @@
 Listen 8080
 <VirtualHost *:8080>
-  DocumentRoot /nominatim/website
-  CustomLog "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/access.log 86400" combined
-  ErrorLog  "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/error.log 86400"
-  LogLevel info
-  <Directory /nominatim/website>
-    Options FollowSymLinks MultiViews
-    DirectoryIndex search.php
-    Require all granted
-  </Directory>
-  AddType text/html .php
+        DocumentRoot /app/src/build/website
+        CustomLog "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/access.log 86400" combined
+        ErrorLog  "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/error.log 86400"
+        LogLevel info
+        <Directory /app/src/build/website>
+                Options FollowSymLinks MultiViews
+                DirectoryIndex search.php
+                Require all granted
+        </Directory>
+        AddType text/html .php
 </VirtualHost>

--- a/3.5/nominatim.conf
+++ b/3.5/nominatim.conf
@@ -1,13 +1,13 @@
 Listen 8080
 <VirtualHost *:8080>
-        DocumentRoot /app/src/build/website
-        CustomLog /var/log/apache2/access.log combined
-        ErrorLog /var/log/apache2/error.log
-        LogLevel debug
-        <Directory /app/src/build/website>
-                Options FollowSymLinks MultiViews
-                DirectoryIndex search.php
-                Require all granted
-        </Directory>
-        AddType text/html .php
+  DocumentRoot /nominatim/website
+  CustomLog "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/access.log 86400" combined
+  ErrorLog  "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/error.log 86400"
+  LogLevel info
+  <Directory /nominatim/website>
+    Options FollowSymLinks MultiViews
+    DirectoryIndex search.php
+    Require all granted
+  </Directory>
+  AddType text/html .php
 </VirtualHost>

--- a/3.6/conf.d/apache.conf
+++ b/3.6/conf.d/apache.conf
@@ -1,13 +1,13 @@
 Listen 8080
 <VirtualHost *:8080>
-  DocumentRoot /nominatim/website
-  CustomLog "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/access.log 86400" combined
-  ErrorLog  "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/error.log 86400"
-  LogLevel info
-  <Directory /nominatim/website>
-    Options FollowSymLinks MultiViews
-    DirectoryIndex search.php
-    Require all granted
-  </Directory>
-  AddType text/html .php
+        DocumentRoot /app/src/build/website
+        CustomLog "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/access.log 86400" combined
+        ErrorLog  "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/error.log 86400"
+        LogLevel info
+        <Directory /app/src/build/website>
+                Options FollowSymLinks MultiViews
+                DirectoryIndex search.php
+                Require all granted
+        </Directory>
+        AddType text/html .php
 </VirtualHost>

--- a/3.6/conf.d/apache.conf
+++ b/3.6/conf.d/apache.conf
@@ -1,13 +1,13 @@
 Listen 8080
 <VirtualHost *:8080>
-        DocumentRoot /app/src/build/website
-        CustomLog /var/log/apache2/access.log combined
-        ErrorLog /var/log/apache2/error.log
-        LogLevel debug
-        <Directory /app/src/build/website>
-                Options FollowSymLinks MultiViews
-                DirectoryIndex search.php
-                Require all granted
-        </Directory>
-        AddType text/html .php
+  DocumentRoot /nominatim/website
+  CustomLog "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/access.log 86400" combined
+  ErrorLog  "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/error.log 86400"
+  LogLevel info
+  <Directory /nominatim/website>
+    Options FollowSymLinks MultiViews
+    DirectoryIndex search.php
+    Require all granted
+  </Directory>
+  AddType text/html .php
 </VirtualHost>

--- a/3.7/conf.d/apache.conf
+++ b/3.7/conf.d/apache.conf
@@ -1,9 +1,9 @@
 Listen 8080
 <VirtualHost *:8080>
   DocumentRoot /nominatim/website
-  CustomLog /var/log/apache2/access.log combined
-  ErrorLog /var/log/apache2/error.log
-  LogLevel debug
+  CustomLog "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/access.log 86400" combined
+  ErrorLog  "|$/usr/bin/rotatelogs -n 7 /var/log/apache2/error.log 86400"
+  LogLevel info
   <Directory /nominatim/website>
     Options FollowSymLinks MultiViews
     DirectoryIndex search.php


### PR DESCRIPTION
based on the discussion in the previous attempt (https://github.com/mediagis/nominatim-docker/pull/206) here is a better solution (thanks @leonardehrenfried).

* Rotate access & error log every 24 hours
* keep 7 files per log
* switched loglevel to info from debug

fixes https://github.com/mediagis/nominatim-docker/issues/205

Test results after setting rotate to 60 seconds locally:

```
-rw-r--r-- 1 root root  2676 May 12 11:22 access_log
-rw-r--r-- 1 root root 11150 May 12 11:14 access_log.1
-rw-r--r-- 1 root root  4237 May 12 11:15 access_log.2
-rw-r--r-- 1 root root   223 May 12 11:16 access_log.3
-rw-r--r-- 1 root root   223 May 12 11:17 access_log.4
-rw-r--r-- 1 root root   223 May 12 11:20 access_log.5
-rw-r--r-- 1 root root   892 May 12 11:21 access_log.6
```