### PR TITLE
Small compilation tweak: make -j nproc

### DIFF
--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -76,7 +76,7 @@ RUN true \
     && mkdir build \
     && cd build \
     && cmake ../Nominatim-$NOMINATIM_VERSION \
-    && make \
+    && make -j`nproc` \
     && make install
 
 RUN true \


### PR DESCRIPTION
I saw in 3.6 release you used `make -j nproc` but not in 3.7, so here's a quick fix.