### PR TITLE
Replace CMD with RUN

### DIFF
--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -109,7 +109,6 @@ RUN true \
 
 # Apache configuration
 COPY conf.d/apache.conf /etc/apache2/sites-enabled/000-default.conf
-RUN a2enconf nominatim
 
 # Postgres config overrides to improve import performance (but reduce crash recovery safety)
 COPY conf.d/postgres-import.conf /etc/postgresql/12/main/conf.d/
@@ -132,7 +131,6 @@ ENV NOMINATIM_PASSWORD qaIACxO6wMR3
 ENV THREADS=16
 
 ENV PROJECT_DIR /nominatim
-RUN mkdir ${PROJECT_DIR}
 
 WORKDIR /app
 

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -109,7 +109,7 @@ RUN true \
 
 # Apache configuration
 COPY conf.d/apache.conf /etc/apache2/sites-enabled/000-default.conf
-CMD a2enconf nominatim
+RUN a2enconf nominatim
 
 # Postgres config overrides to improve import performance (but reduce crash recovery safety)
 COPY conf.d/postgres-import.conf /etc/postgresql/12/main/conf.d/
@@ -132,7 +132,7 @@ ENV NOMINATIM_PASSWORD qaIACxO6wMR3
 ENV THREADS=16
 
 ENV PROJECT_DIR /nominatim
-CMD mkdir ${PROJECT_DIR}
+RUN mkdir ${PROJECT_DIR}
 
 WORKDIR /app
 


### PR DESCRIPTION
As pointed out by @r3pl1x there are multiple CMD lines in the Dockerfile where they shouldn't be.

~~The image still runs fine as they are treated like a RUN but their presence makes the build hard to cache hence why I'm converting them.~~

Turns out they are never run and are not needed at all, isn't it?