### PR TITLE
Allow imports from local files, add option to freeze database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,17 @@ jobs:
           sleep 35
           ./assert-non-empty-json "http://localhost:8008/search.php?q=avenue%20pasteur"
 
+      - name: Check when using FREEZE
+        working-directory: .github/workflows
+        run: |-
+          docker run -i --rm \
+            -e PBF_URL=http://download.geofabrik.de/europe/monaco-latest.osm.pbf \
+            -e FREEZE="true" \
+            -p 8008:8080 \
+            nominatim &
+          sleep 35
+          ./assert-non-empty-json "http://localhost:8008/search.php?q=avenue%20pasteur"
+
       - name: Login to DockerHub
         if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'mediagis' }}
         uses: docker/login-action@v1

--- a/4.0/README.md
+++ b/4.0/README.md
@@ -28,9 +28,10 @@ The following environment variables are available for configuration:
   - `REPLICATION_URL`: Where to get updates from. Also available from Geofabrik.
   - `REPLICATION_UPDATE_INTERVAL`: How often upstream publishes diffs (in seconds, default: `86400`). _Requires `REPLICATION_URL` to be set._
   - `REPLICATION_RECHECK_INTERVAL`: How long to sleep if no update found yet (in seconds, default: `900`). _Requires `REPLICATION_URL` to be set._
-  - `IMPORT_WIKIPEDIA`: Whether to import the Wikipedia importance dumps, which improve the scoring of results. On a beefy 10 core server, this takes around 5 minutes. (default: `false`)
-  - `IMPORT_US_POSTCODES`: Whether to import the US postcode dump. (default: `false`)
-  - `IMPORT_GB_POSTCODES`: Whether to import the GB postcode dump. (default: `false`)
+  - `IMPORT_WIKIPEDIA`: Whether to download and import the Wikipedia importance dumps (`true`) or path to importance dump in the container. Importance dumps improve the scoring of results. On a beefy 10 core server, this takes around 5 minutes. (default: `false`)
+  - `IMPORT_US_POSTCODES`: Whether to download and import the US postcode dump (`true`) or path to US postcode dump in the container. (default: `false`)
+  - `IMPORT_GB_POSTCODES`: Whether to download and import the GB postcode dump (`true`) or path to GB postcode dump in the container. (default: `false`)
+  - `IMPORT_TIGER_ADDRESSES`: Whether to download and import the Tiger address data (`true`) or path to a preprocessed Tiger address set in the container. (default: `false`)
   - `THREADS`: How many threads should be used to import (default: `16`)
   - `NOMINATIM_PASSWORD`: The password to connect to the database with (default: `qaIACxO6wMR3`)
 
@@ -148,6 +149,24 @@ docker run -it --rm \
   mediagis/nominatim:4.0
 ```
 where the _/osm-maps/data/_ directory contains _merged.osm.pbf_ file that is mounted and available in container: _/nominatim/data/merged.osm.pbf_
+
+## Importance Dumps, Postcode Data, and Tiger Addresses
+
+Including the Wikipedia importance dumps, postcode files, and Tiger address data can improve results. These can be automatically downloaded by setting the appropriate options (see above) to `true`. Alternatively, they can be imported from local files by specifying a file path (relative to the container), similar to how `PBF_PATH` is used. For example:
+
+``` sh
+docker run -it --rm \
+  -e PBF_URL=https://download.geofabrik.de/europe/monaco-latest.osm.pbf \
+  -e IMPORT_WIKIPEDIA=/nominatim/extras/wikimedia-importance.sql.gz \
+  -p 8080:8080 \
+  -v /osm-maps/extras:/nominatim/extras \
+  --name nominatim \
+  mediagis/nominatim:4.0
+```
+
+Where the path to the importance dump is given relative to the container. (The file does not need to be named `wikimedia-importance.sql.gz`.) The same works for `IMPORT_US_POSTCODES` and `IMPORT_GB_POSTCODES`.
+
+For more information about the Tiger address file, see [Installing TIGER housenumber data for the US](https://nominatim.org/release-docs/4.0.1/customize/Tiger/).
 
 ## Development
 

--- a/4.0/README.md
+++ b/4.0/README.md
@@ -28,6 +28,7 @@ The following environment variables are available for configuration:
   - `REPLICATION_URL`: Where to get updates from. Also available from Geofabrik.
   - `REPLICATION_UPDATE_INTERVAL`: How often upstream publishes diffs (in seconds, default: `86400`). _Requires `REPLICATION_URL` to be set._
   - `REPLICATION_RECHECK_INTERVAL`: How long to sleep if no update found yet (in seconds, default: `900`). _Requires `REPLICATION_URL` to be set._
+  - `FREEZE`: Freeze database and disable dynamic updates to save space. (default: `false`)
   - `IMPORT_WIKIPEDIA`: Whether to download and import the Wikipedia importance dumps (`true`) or path to importance dump in the container. Importance dumps improve the scoring of results. On a beefy 10 core server, this takes around 5 minutes. (default: `false`)
   - `IMPORT_US_POSTCODES`: Whether to download and import the US postcode dump (`true`) or path to US postcode dump in the container. (default: `false`)
   - `IMPORT_GB_POSTCODES`: Whether to download and import the GB postcode dump (`true`) or path to GB postcode dump in the container. (default: `false`)

--- a/4.0/config.sh
+++ b/4.0/config.sh
@@ -9,7 +9,7 @@ if [[ "$PBF_URL" = "" && "$PBF_PATH" = "" ]]  ||  [[ "$PBF_URL" != "" && "$PBF_P
 fi
 
 if [ "$REPLICATION_URL" != "" ]; then
-    sed -i "s|__REPLICATION_URL__|$REPLICATION_URL|g" ${CONFIG_FILE}    
+    sed -i "s|__REPLICATION_URL__|$REPLICATION_URL|g" ${CONFIG_FILE}
 fi
 
 # Use the specified replication update and recheck interval values if either or both are numbers, or use the default values
@@ -54,3 +54,9 @@ fi
 # if flatnode directory was created by volume / mount, use flatnode files
 
 if [ -d "${PROJECT_DIR}/flatnode" ]; then sed -i 's\^NOMINATIM_FLATNODE_FILE=$\NOMINATIM_FLATNODE_FILE="/nominatim/flatnode/flatnode.file"\g' ${CONFIG_FILE}; fi
+
+# enable use of optional TIGER address data
+
+if [ "$IMPORT_TIGER_ADDRESSES" = "true" ] || [ -f "$IMPORT_TIGER_ADDRESSES" ]; then
+  echo NOMINATIM_USE_US_TIGER_DATA=yes >> ${CONFIG_FILE}
+fi

--- a/4.0/init.sh
+++ b/4.0/init.sh
@@ -81,6 +81,14 @@ sudo -u nominatim nominatim admin --check-database
 
 if [ "$REPLICATION_URL" != "" ]; then
   sudo -E -u nominatim nominatim replication --init
+  if [ "$FREEZE" = "true" ]; then
+    echo "Skipping freeze because REPLICATION_URL is not empty"
+  fi
+else
+  if [ "$FREEZE" = "true" ]; then
+    echo "Freezing database"
+    sudo -u nominatim nominatim freeze
+  fi
 fi
 
 sudo service postgresql stop

--- a/4.0/init.sh
+++ b/4.0/init.sh
@@ -100,6 +100,7 @@ rm /etc/postgresql/12/main/conf.d/postgres-import.conf
 
 echo "Deleting downloaded dumps in ${PROJECT_DIR}"
 rm -f ${PROJECT_DIR}/*sql.gz
+rm -f ${PROJECT_DIR}/tiger2021-nominatim-preprocessed.csv.tar.gz
 
 # nominatim needs the tokenizer configuration in the project directory to start up
 # but when you start the container with an already imported DB then you don't have this config.

--- a/4.0/init.sh
+++ b/4.0/init.sh
@@ -91,6 +91,9 @@ else
   fi
 fi
 
+# gather statistics for query planner to potentially improve query performance
+# see, https://github.com/osm-search/Nominatim/issues/1023
+# and  https://github.com/osm-search/Nominatim/issues/1139
 sudo -u nominatim psql -d nominatim -c "ANALYZE VERBOSE"
 
 sudo service postgresql stop

--- a/4.0/init.sh
+++ b/4.0/init.sh
@@ -91,6 +91,8 @@ else
   fi
 fi
 
+sudo -u nominatim psql -d nominatim -c "ANALYZE VERBOSE"
+
 sudo service postgresql stop
 
 # Remove slightly unsafe postgres config overrides that made the import faster

--- a/4.0/init.sh
+++ b/4.0/init.sh
@@ -31,10 +31,10 @@ else
 fi;
 
 if [ "$IMPORT_TIGER_ADDRESSES" = "true" ]; then
-  curl https://nominatim.org/data/tiger2021-nominatim-preprocessed.csv.tar.gz -L -o ${PROJECT_DIR}/tiger2021-nominatim-preprocessed.csv.tar.gz
+  curl https://nominatim.org/data/tiger2021-nominatim-preprocessed.csv.tar.gz -L -o ${PROJECT_DIR}/tiger-nominatim-preprocessed.csv.tar.gz
 elif [ -f "$IMPORT_TIGER_ADDRESSES" ]; then
   # use local file if asked
-  ln -s "$IMPORT_TIGER_ADDRESSES" ${PROJECT_DIR}/tiger2021-nominatim-preprocessed.csv.tar.gz
+  ln -s "$IMPORT_TIGER_ADDRESSES" ${PROJECT_DIR}/tiger-nominatim-preprocessed.csv.tar.gz
 else
   echo "Skipping optional Tiger addresses import"
 fi
@@ -70,9 +70,9 @@ chown -R nominatim:nominatim ${PROJECT_DIR}
 cd ${PROJECT_DIR}
 sudo -E -u nominatim nominatim import --osm-file $OSMFILE --threads $THREADS
 
-if [ -f tiger2021-nominatim-preprocessed.csv.tar.gz ]; then
+if [ -f tiger-nominatim-preprocessed.csv.tar.gz ]; then
   echo "Importing Tiger address data"
-  sudo -u nominatim nominatim add-data --tiger-data tiger2021-nominatim-preprocessed.csv.tar.gz
+  sudo -u nominatim nominatim add-data --tiger-data tiger-nominatim-preprocessed.csv.tar.gz
 fi
 
 sudo -u nominatim nominatim admin --check-database
@@ -101,7 +101,7 @@ rm /etc/postgresql/12/main/conf.d/postgres-import.conf
 
 echo "Deleting downloaded dumps in ${PROJECT_DIR}"
 rm -f ${PROJECT_DIR}/*sql.gz
-rm -f ${PROJECT_DIR}/tiger2021-nominatim-preprocessed.csv.tar.gz
+rm -f ${PROJECT_DIR}/tiger-nominatim-preprocessed.csv.tar.gz
 
 # nominatim needs the tokenizer configuration in the project directory to start up
 # but when you start the container with an already imported DB then you don't have this config.

--- a/4.0/init.sh
+++ b/4.0/init.sh
@@ -73,8 +73,6 @@ sudo -E -u nominatim nominatim import --osm-file $OSMFILE --threads $THREADS
 if [ -f tiger2021-nominatim-preprocessed.csv.tar.gz ]; then
   echo "Importing Tiger address data"
   sudo -u nominatim nominatim add-data --tiger-data tiger2021-nominatim-preprocessed.csv.tar.gz
-  echo NOMINATIM_USE_US_TIGER_DATA=yes >> ${PROJECT_DIR}/.env
-  sudo -u nominatim nominatim refresh --functions
 fi
 
 sudo -u nominatim nominatim admin --check-database

--- a/4.0/start.sh
+++ b/4.0/start.sh
@@ -38,7 +38,7 @@ fi
 
 service postgresql start
 
-cd ${PROJECT_DIR} && sudo -u nominatim nominatim refresh --website
+cd ${PROJECT_DIR} && sudo -u nominatim nominatim refresh --website --functions
 
 service apache2 start
 


### PR DESCRIPTION
These commits accomplish the following:

* Allow Wikipedia and post code data to be imported from local files, similar to `PBF_PATH`. My use case for this is running Nominatim in restricted research environments where connecting to the outside internet is not allowed/possible.
* Enable [importing TIGER address data](https://nominatim.org/release-docs/latest/customize/Tiger/), either from a local file or via automatic download.
* [Freeze database after import](https://nominatim.org/release-docs/latest/admin/Import/#dropping-data-required-for-dynamic-updates). This saves space at the cost of turning off future updates.
* Finally, analyze the database after import, which may help with queries taking too long, according to osm-search/Nominatim#1023.