### PR TITLE
Add some features (replication on container start, init/replication/query log files, ...)

### DIFF
--- a/4.0/config.sh
+++ b/4.0/config.sh
@@ -54,3 +54,18 @@ fi
 # if flatnode directory was created by volume / mount, use flatnode files
 
 if [ -d "${PROJECT_DIR}/flatnode" ]; then sed -i 's\^NOMINATIM_FLATNODE_FILE=$\NOMINATIM_FLATNODE_FILE="/nominatim/flatnode/flatnode.file"\g' ${CONFIG_FILE}; fi
+
+# log query
+
+if [ ! -z "$NOMINATIM_LOG_FILE" ]; then
+  # add empty 'NOMINATIM_LOG_FILE=' variable before change it for previously created or imported .env file
+  if ! grep -Fq 'NOMINATIM_LOG_FILE=' ${CONFIG_FILE}; then
+    echo 'NOMINATIM_LOG_FILE=' >> ${CONFIG_FILE}
+  fi
+  sed -i "s#^NOMINATIM_LOG_FILE=.*\$#NOMINATIM_LOG_FILE=${NOMINATIM_LOG_FILE}#g" ${CONFIG_FILE}
+  # log file must be writable by the user running apache2 : www-data
+  touch ${NOMINATIM_LOG_FILE} && chown -R www-data ${NOMINATIM_LOG_FILE}
+else
+  # remove NOMINATIM_LOG_FILE value from .env file when unsetting environment variable
+  sed -i "s#^NOMINATIM_LOG_FILE=.*\$#NOMINATIM_LOG_FILE=#g" ${CONFIG_FILE}
+fi

--- a/4.0/start.sh
+++ b/4.0/start.sh
@@ -6,22 +6,35 @@ stopServices() {
 }
 trap stopServices TERM
 
+# Needed to create default .env file before calling /app/config.sh if /nominatim is a persistent volume
+if [ ! -f ${PROJECT_DIR}/.env ]; then
+  cat << EOT > ${PROJECT_DIR}/.env 
+NOMINATIM_REPLICATION_URL=__REPLICATION_URL__
+NOMINATIM_REPLICATION_UPDATE_INTERVAL=86400
+NOMINATIM_REPLICATION_RECHECK_INTERVAL=900
+NOMINATIM_IMPORT_STYLE=__IMPORT_STYLE__
+NOMINATIM_DATABASE_MODULE_PATH=/usr/local/lib/nominatim/module/
+NOMINATIM_FLATNODE_FILE=
+NOMINATIM_LOG_FILE=
+EOT
+fi
+
 /app/config.sh
 
 if id nominatim >/dev/null 2>&1; then
   echo "user nominatim already exists"
 else
-  useradd -m -p ${NOMINATIM_PASSWORD} nominatim
+  groupadd --gid 6000 nominatim
+  useradd -m --uid 6000 --gid 6000 -p ${NOMINATIM_PASSWORD} nominatim
 fi
 
 IMPORT_FINISHED=/var/lib/postgresql/12/main/import-finished
 TOKENIZER_DIR=${PROJECT_DIR}/tokenizer
 
 if [ ! -f ${IMPORT_FINISHED} ]; then
-  /app/init.sh
+  mkdir -p $(dirname ${NOMINATIM_INIT_LOG:-/var/log/nominatim/init.log})
+  /app/init.sh > ${NOMINATIM_INIT_LOG:-/var/log/nominatim/init.log} 2>&1
   touch ${IMPORT_FINISHED}
-else
-  chown -R nominatim:nominatim ${PROJECT_DIR}
 fi
 
 if [ ! -d ${TOKENIZER_DIR} ]; then
@@ -33,12 +46,47 @@ if [ ! -d ${TOKENIZER_DIR} ]; then
   # More reading: https://github.com/mediagis/nominatim-docker/pull/274/
   echo "No tokenizer configuration found. Copying from persistent volume into project directory."
   cp -r /var/lib/postgresql/12/main/tokenizer ${TOKENIZER_DIR}
-  chown -R nominatim:nominatim ${PROJECT_DIR}
 fi
+
+chown -R nominatim:nominatim ${PROJECT_DIR}
 
 service postgresql start
 
 cd ${PROJECT_DIR} && sudo -u nominatim nominatim refresh --website
+
+# start replication on container (re)start
+if [ "$REPLICATION_URL" != "" ]; then
+  mkdir -p $(dirname ${NOMINATIM_REPLICATION_LOG:-/var/log/nominatim/replication.log})
+  sudo -E -u nominatim nominatim replication > ${NOMINATIM_REPLICATION_LOG:-/var/log/nominatim/replication.log} 2>&1 &
+  cat << EOT > /etc/logrotate.d/nominatim_replication
+${NOMINATIM_REPLICATION_LOG:-/var/log/nominatim/replication.log} {
+        weekly
+        rotate 10
+        size 50M
+        copytruncate
+        delaycompress
+        compress
+        notifempty
+        missingok
+        su root root
+}
+EOT
+fi
+
+if [ "$NOMINATIM_LOG_FILE" != "" ]; then
+  # based on /etc/logrotate.d/apache2
+  cat << EOT > /etc/logrotate.d/nominatim_query
+${NOMINATIM_LOG_FILE:-/var/log/nominatim/query.log} {
+	daily
+	missingok
+	rotate 15
+	compress
+	delaycompress
+	notifempty
+	create 644 www-data www-data
+}
+EOT
+fi
 
 service apache2 start
 


### PR DESCRIPTION
PR opened to propose some modifications we've made to our setup

* we use persistent volumes for '/nominatim' (for .env file) and
  '/var/log/nominatim'
* download and import TIGER datas (to be removed if
  https://github.com/mediagis/nominatim-docker/pull/293 is merged)
* restart replication on container restart + redirect replication logs
  to a file
* handle adding and removing NOMINATIM_LOG_FILE configuration
* handle logrotate configuration for added log files
* we like to have matching uid/gid for the files in the persistent
  volumes between the host and the container, this part could be ignored
  
 EDIT : logrotate files are handled this way because i didn't rebuild the docker image, they should be in 'conf.d/' and copied with the Dockerfile 