### PR TITLE
./config.sh: line 26: [{FILE}: No such file or directory

### DIFF
--- a/4.0/config.sh
+++ b/4.0/config.sh
@@ -16,7 +16,7 @@ fi
 
 reg_num='^[0-9]+$'
 if [[ $REPLICATION_UPDATE_INTERVAL =~ $reg_num ]]; then
-    if ["$REPLICATION_URL" = ""]; then
+    if [ "$REPLICATION_URL" = "" ]; then
         echo "You need to specify the REPLICATION_URL variable in order to set a REPLICATION_UPDATE_INTERVAL"
         exit 1
     fi

--- a/4.0/config.sh
+++ b/4.0/config.sh
@@ -23,7 +23,7 @@ if [[ $REPLICATION_UPDATE_INTERVAL =~ $reg_num ]]; then
     sed -i "s/NOMINATIM_REPLICATION_UPDATE_INTERVAL=86400/NOMINATIM_REPLICATION_UPDATE_INTERVAL=$REPLICATION_UPDATE_INTERVAL/g" ${CONFIG_FILE}
 fi
 if [[ $REPLICATION_RECHECK_INTERVAL =~ $reg_num ]]; then
-    if ["$REPLICATION_URL" = ""]; then
+    if [ "$REPLICATION_URL" = "" ]; then
         echo "You need to specify the REPLICATION_URL variable in order to set a REPLICATION_RECHECK_INTERVAL"
         exit 1
     fi


### PR DESCRIPTION
Hi,

I've found out that config.sh contains a bug while retrieving $REPLICATION_URL in order to update the database. Turns out, shell language was not respected on line 26 (spaces between [, ] and expressions). Starting the container with the pre-requisite parameters give you this warning / error message : 

`./config.sh: line 26: [https://download.geofabrik.de/europe/monaco-updates/: No such file or directory`

Simple fix here.