### PR TITLE
Supervisor integration

### DIFF
--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -120,6 +120,10 @@ COPY start.sh /app/start.sh
 COPY startapache.sh /app/startapache.sh
 COPY startpostgres.sh /app/startpostgres.sh
 
+# Supervisor
+RUN apt-get -y update -qq && apt-get -y install supervisor && apt-get clean
+COPY conf.d/replication.conf /etc/supervisor/conf.d/replication.conf
+
 # Collapse image to single layer.
 FROM scratch
 

--- a/3.7/conf.d/replication.conf
+++ b/3.7/conf.d/replication.conf
@@ -1,0 +1,11 @@
+[program:replication]
+command=nominatim replication --project-dir /nominatim
+user=nominatim
+process_name=%(program_name)s_%(process_num)02d
+numprocs=1
+autostart=true
+autorestart=true
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/3.7/start.sh
+++ b/3.7/start.sh
@@ -27,6 +27,7 @@ cd ${PROJECT_DIR} && nominatim refresh --website
 
 service postgresql start
 service apache2 start
+service supervisor start
 
 # fork a process and wait for it
 tail -f /var/log/postgresql/postgresql-12-main.log &

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -121,6 +121,10 @@ COPY start.sh /app/start.sh
 COPY startapache.sh /app/startapache.sh
 COPY startpostgres.sh /app/startpostgres.sh
 
+# Supervisor
+RUN apt-get -y update -qq && apt-get -y install supervisor && apt-get clean
+COPY conf.d/replication.conf /etc/supervisor/conf.d/replication.conf
+
 # Collapse image to single layer.
 FROM scratch
 

--- a/4.0/conf.d/replication.conf
+++ b/4.0/conf.d/replication.conf
@@ -1,0 +1,11 @@
+[program:replication]
+command=nominatim replication --project-dir /nominatim
+user=nominatim
+process_name=%(program_name)s_%(process_num)02d
+numprocs=1
+autostart=true
+autorestart=true
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/4.0/start.sh
+++ b/4.0/start.sh
@@ -41,6 +41,7 @@ service postgresql start
 cd ${PROJECT_DIR} && sudo -E -u nominatim nominatim refresh --website --functions
 
 service apache2 start
+service supervisor start
 
 # fork a process and wait for it
 tail -f /var/log/postgresql/postgresql-12-main.log &


### PR DESCRIPTION
I faced the problem with updating the maps.
The process `nominatim replication --project-dir /nominatim` works some time and then crashes.
So I've added supervisor to wrap replication process to make it stable.