### PR TITLE
Continous replication, shutdown fix, output apache logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           ./assert-non-empty-json "http://localhost:8001/search.php?q=avenue%20pasteur"
           docker stop nominatim
 
-      - name: Check import with mount
+      - name: Check import with volume mount
         working-directory: .github/workflows
         run: |-
           docker run -i --rm \
@@ -96,18 +96,17 @@ jobs:
           ./assert-non-empty-json "http://localhost:8004/search.php?q=avenue%20pasteur"
           docker stop nominatim
 
-      - name: Check UPDATE_MODE=once with bind-mount
+      - name: Check UPDATE_MODE=once with volume
+        if: ! matrix.nominatim.version == "4.0"
         working-directory: .github/workflows
         run: |-
-          # remove existing data for fresh import
-          rm -rf /tmp/nominatim-data
           # get the data from four days ago to make sure there really are updates to apply
           four_days_ago=`date --date="4 days ago" +%y%m%d`
           docker run -i --rm \
             -e PBF_URL=http://download.geofabrik.de/europe/monaco-${four_days_ago}.osm.pbf \
             -e REPLICATION_URL=http://download.geofabrik.de/europe/monaco-updates/ \
             -e UPDATE_MODE=once \
-            -v /tmp/nominatim-data:/var/lib/postgresql/${{ matrix.nominatim.postgres_version }}/main \
+            -v nominatim-update-volume:/var/lib/postgresql/${{ matrix.nominatim.postgres_version }}/main \
             -p 8004:8080 \
             --name nominatim \
             nominatim &
@@ -118,19 +117,20 @@ jobs:
           docker stop nominatim
 
       - name: Check UPDATE_MODE=continuous with bind-mount
+        if: ! matrix.nominatim.version == "4.0"
         working-directory: .github/workflows
         run: |-
-          # get the data from four days ago to make sure there really are updates to apply
-          four_days_ago=`date --date="4 days ago" +%y%m%d`
+          # get the data from few days ago to make sure there really are updates to apply
+          days_ago=`date --date="10 days ago" +%y%m%d`
           docker run -i --rm \
-            -e PBF_URL=http://download.geofabrik.de/europe/monaco-${four_days_ago}.osm.pbf \
+            -e PBF_URL=http://download.geofabrik.de/europe/monaco-${days_ago}.osm.pbf \
             -e REPLICATION_URL=http://download.geofabrik.de/europe/monaco-updates/ \
             -e UPDATE_MODE=continuous \
-            -v /tmp/nominatim-data:/var/lib/postgresql/${{ matrix.nominatim.postgres_version }}/main \
+            -v /tmp/nominatim-update-bindmount:/var/lib/postgresql/${{ matrix.nominatim.postgres_version }}/main \
             -p 8004:8080 \
             --name nominatim \
             nominatim &
-          sleep 60
+          sleep 120
           ./assert-non-empty-json "http://localhost:8004/search.php?q=avenue%20pasteur"
           echo "check replication log for Update completed. Count:"
           docker exec -i nominatim grep -c 'Update completed.' /var/log/replication.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             postgres_version: 12
           - version: "4.1"
             update_command: docker exec -i nominatim sudo -u nominatim nominatim replication --project-dir /nominatim --once
-            postgres_version: 14 
+            postgres_version: 14
 
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
             -p 8001:8080 \
             --name nominatim \
             nominatim &
-          sleep 60
+          sleep 90
           ./assert-non-empty-json "http://localhost:8001/search.php?q=avenue%20pasteur"
           ${{ matrix.nominatim.update_command }}
           ./assert-non-empty-json "http://localhost:8001/search.php?q=avenue%20pasteur"
@@ -59,27 +59,29 @@ jobs:
             -v nominatim-data:/var/lib/postgresql/${{ matrix.nominatim.postgres_version }}/main \
             -p 8002:8080 \
             nominatim &
-          sleep 60
+          sleep 90
           ./assert-non-empty-json "http://localhost:8002/search.php?q=avenue%20pasteur"
 
       - name: Check import with bind-mount
         working-directory: .github/workflows
         run: |-
+          # get the data from four days ago to make sure there really are updates to apply
+          four_days_ago=`date --date="4 days ago" +%y%m%d`
           docker run -i --rm \
-            -e PBF_URL=http://download.geofabrik.de/europe/monaco-latest.osm.pbf \
+            -e PBF_URL=http://download.geofabrik.de/europe/monaco-${four_days_ago}.osm.pbf \
             -e REPLICATION_URL=http://download.geofabrik.de/europe/monaco-updates/ \
             -v /tmp/nominatim-data:/var/lib/postgresql/${{ matrix.nominatim.postgres_version }}/main \
             -p 8003:8080 \
             --name nominatim \
             nominatim &
-          sleep 60
+          sleep 90
           ./assert-non-empty-json "http://localhost:8003/search.php?q=avenue%20pasteur"
           docker stop nominatim
 
       - name: Check container restart and update with bind-mount
         working-directory: .github/workflows
         run: |-
-          # get the data from four days ago to make sure there really are updates to apply
+          # import to bind mount is done by previous step
           four_days_ago=`date --date="4 days ago" +%y%m%d`
           docker run -i --rm \
             -e PBF_URL=http://download.geofabrik.de/europe/monaco-${four_days_ago}.osm.pbf \
@@ -94,6 +96,46 @@ jobs:
           ./assert-non-empty-json "http://localhost:8004/search.php?q=avenue%20pasteur"
           docker stop nominatim
 
+      - name: Check UPDATE_MODE=once with bind-mount
+        working-directory: .github/workflows
+        run: |-
+          # remove existing data for fresh import
+          rm -rf /tmp/nominatim-data
+          # get the data from four days ago to make sure there really are updates to apply
+          four_days_ago=`date --date="4 days ago" +%y%m%d`
+          docker run -i --rm \
+            -e PBF_URL=http://download.geofabrik.de/europe/monaco-${four_days_ago}.osm.pbf \
+            -e REPLICATION_URL=http://download.geofabrik.de/europe/monaco-updates/ \
+            -e UPDATE_MODE=once \
+            -v /tmp/nominatim-data:/var/lib/postgresql/${{ matrix.nominatim.postgres_version }}/main \
+            -p 8004:8080 \
+            --name nominatim \
+            nominatim &
+          sleep 120
+          ./assert-non-empty-json "http://localhost:8004/search.php?q=avenue%20pasteur"
+          echo "check replication log for Update completed. Count:"
+          docker exec -i nominatim grep -c 'Update completed.' /var/log/replication.log
+          docker stop nominatim
+
+      - name: Check UPDATE_MODE=continuous with bind-mount
+        working-directory: .github/workflows
+        run: |-
+          # get the data from four days ago to make sure there really are updates to apply
+          four_days_ago=`date --date="4 days ago" +%y%m%d`
+          docker run -i --rm \
+            -e PBF_URL=http://download.geofabrik.de/europe/monaco-${four_days_ago}.osm.pbf \
+            -e REPLICATION_URL=http://download.geofabrik.de/europe/monaco-updates/ \
+            -e UPDATE_MODE=continuous \
+            -v /tmp/nominatim-data:/var/lib/postgresql/${{ matrix.nominatim.postgres_version }}/main \
+            -p 8004:8080 \
+            --name nominatim \
+            nominatim &
+          sleep 60
+          ./assert-non-empty-json "http://localhost:8004/search.php?q=avenue%20pasteur"
+          echo "check replication log for Update completed. Count:"
+          docker exec -i nominatim grep -c 'Update completed.' /var/log/replication.log
+          docker stop nominatim
+
       - name: Check import full style
         working-directory: .github/workflows
         run: |-
@@ -103,7 +145,7 @@ jobs:
             -e IMPORT_STYLE=full \
             -p 8005:8080 \
             nominatim &
-          sleep 60
+          sleep 90
           ./assert-non-empty-json "http://localhost:8005/search.php?q=hotel%20de%20paris"
 
       - name: Check import admin style
@@ -115,7 +157,7 @@ jobs:
             -e IMPORT_STYLE=admin \
             -p 8006:8080 \
             nominatim &
-          sleep 60
+          sleep 90
           ./assert-empty-json "http://localhost:8006/search.php?q=hotel%20de%20paris"
 
       - name: Check import with PBF_PATH
@@ -130,7 +172,7 @@ jobs:
             -p 8007:8080 \
             --name nominatim \
             nominatim &
-          sleep 60
+          sleep 90
           ./assert-non-empty-json "http://localhost:8007/search.php?q=avenue%20pasteur"
           docker stop nominatim
           docker volume rm nominatim7-data
@@ -142,7 +184,7 @@ jobs:
             -e PBF_URL=http://download.geofabrik.de/europe/monaco-latest.osm.pbf \
             -p 8008:8080 \
             nominatim &
-          sleep 60
+          sleep 90
           ./assert-non-empty-json "http://localhost:8008/search.php?q=avenue%20pasteur"
 
       - name: Check when using FREEZE
@@ -153,7 +195,7 @@ jobs:
             -e FREEZE="true" \
             -p 8008:8080 \
             nominatim &
-          sleep 60
+          sleep 90
           ./assert-non-empty-json "http://localhost:8008/search.php?q=avenue%20pasteur"
 
       - name: Check GB postcode import
@@ -180,6 +222,6 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'mediagis' }}
         run: |-
           docker buildx build --platform linux/amd64,linux/arm64 --push \
-             -t mediagis/nominatim:${{ matrix.nominatim.version }} \
-             -t mediagis/nominatim:${{ matrix.nominatim.version }}-${{ github.sha }} .
+            -t mediagis/nominatim:${{ matrix.nominatim.version }} \
+            -t mediagis/nominatim:${{ matrix.nominatim.version }}-${{ github.sha }} .
         working-directory: ${{ matrix.nominatim.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         working-directory: .github/workflows
         run: |-
           # get the data from few days ago to make sure there really are updates to apply
-          days_ago=`date --date="10 days ago" +%y%m%d`
+          days_ago=`date --date="4 days ago" +%y%m%d`
           docker run -i --rm \
             -e PBF_URL=http://download.geofabrik.de/europe/monaco-${days_ago}.osm.pbf \
             -e REPLICATION_URL=http://download.geofabrik.de/europe/monaco-updates/ \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           docker stop nominatim
 
       - name: Check UPDATE_MODE=once with volume
-        if: ! matrix.nominatim.version == "4.0"
+        if: matrix.nominatim.version != '4.0'
         working-directory: .github/workflows
         run: |-
           # get the data from four days ago to make sure there really are updates to apply
@@ -117,7 +117,7 @@ jobs:
           docker stop nominatim
 
       - name: Check UPDATE_MODE=continuous with bind-mount
-        if: ! matrix.nominatim.version == "4.0"
+        if: matrix.nominatim.version != '4.0'
         working-directory: .github/workflows
         run: |-
           # get the data from few days ago to make sure there really are updates to apply

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -140,4 +140,4 @@ EXPOSE 8080
 
 COPY conf.d/env $PROJECT_DIR/.env
 
-CMD /app/start.sh
+CMD ["/app/start.sh"]

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -112,7 +112,7 @@ RUN true \
 COPY conf.d/apache.conf /etc/apache2/sites-enabled/000-default.conf
 
 # Postgres config overrides to improve import performance (but reduce crash recovery safety)
-COPY conf.d/postgres-import.conf /etc/postgresql/14/main/conf.d/
+COPY conf.d/postgres-import.conf /etc/postgresql/14/main/conf.d/postgres-import.conf.disabled
 COPY conf.d/postgres-tuning.conf /etc/postgresql/14/main/conf.d/
 
 COPY config.sh /app/config.sh

--- a/4.1/README.md
+++ b/4.1/README.md
@@ -47,6 +47,7 @@ The following environment variables are available for configuration:
 - `REPLICATION_URL`: Where to get updates from. Also available from Geofabrik.
 - `REPLICATION_UPDATE_INTERVAL`: How often upstream publishes diffs (in seconds, default: `86400`). _Requires `REPLICATION_URL` to be set._
 - `REPLICATION_RECHECK_INTERVAL`: How long to sleep if no update found yet (in seconds, default: `900`). _Requires `REPLICATION_URL` to be set._
+- `UPDATE_MODE`: How to run replication to [update nominatim data](https://nominatim.org/release-docs/4.1.0/admin/Update/#updating-nominatim). Options: `continuous`/`once`/`catch-up`/`none` (default: `none`)
 - `FREEZE`: Freeze database and disable dynamic updates to save space. (default: `false`)
 - `IMPORT_WIKIPEDIA`: Whether to download and import the Wikipedia importance dumps (`true`) or path to importance dump in the container. Importance dumps improve the scoring of results. On a beefy 10 core server, this takes around 5 minutes. (default: `false`)
 - `IMPORT_US_POSTCODES`: Whether to download and import the US postcode dump (`true`) or path to US postcode dump in the container. (default: `false`)

--- a/4.1/contrib/docker-compose-planet.yml
+++ b/4.1/contrib/docker-compose-planet.yml
@@ -18,9 +18,9 @@ services:
             PBF_URL: https://ftp5.gwdg.de/pub/misc/openstreetmap/planet.openstreetmap.org/pbf/planet-latest.osm.pbf
             REPLICATION_URL: https://ftp5.gwdg.de/pub/misc/openstreetmap/planet.openstreetmap.org/replication/day/
             NOMINATIM_PASSWORD: very_secure_password
-            IMPORT_WIKIPEDIA: true
-            IMPORT_US_POSTCODES: true
-            IMPORT_GB_POSTCODES: true
+            IMPORT_WIKIPEDIA: "true"
+            IMPORT_US_POSTCODES: "true"
+            IMPORT_GB_POSTCODES: "true"
             THREADS: 16
         volumes:
             - type: bind
@@ -30,4 +30,3 @@ services:
               source: /data/flatnode
               target: /nominatim/flatnode
         shm_size: 1gb
-

--- a/4.1/init.sh
+++ b/4.1/init.sh
@@ -56,6 +56,9 @@ if [ ! -f /var/lib/postgresql/14/main/PG_VERSION ]; then
   sudo -u postgres /usr/lib/postgresql/14/bin/initdb -D /var/lib/postgresql/14/main
 fi
 
+# temporarily enable unsafe import optimization config
+cp /etc/postgresql/14/main/conf.d/postgres-import.conf.disabled /etc/postgresql/14/main/conf.d/postgres-import.conf
+
 sudo service postgresql start && \
 sudo -E -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='nominatim'" | grep -q 1 || sudo -E -u postgres createuser -s nominatim && \
 sudo -E -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -E -u postgres createuser -SDR www-data && \

--- a/4.1/start.sh
+++ b/4.1/start.sh
@@ -37,18 +37,18 @@ service apache2 start
 # start continous replication process
 if [ "$REPLICATION_URL" != "" ] && [ "$FREEZE" != "true" ]; then
   # run init in case replication settings changed
-  sudo -u nominatim nominatim replication --project-dir /nominatim --init
+  sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --init
   if [ "$UPDATE_MODE" == "continuous" ]; then
     echo "starting continuous replication"
-    sudo -u nominatim nominatim replication --project-dir /nominatim &> /var/log/replication.log &
+    sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} &> /var/log/replication.log &
     replicationpid=${!}
   elif [ "$UPDATE_MODE" == "once" ]; then
     echo "starting replication once"
-    sudo -u nominatim nominatim replication --project-dir /nominatim --once &> /var/log/replication.log &
+    sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --once &> /var/log/replication.log &
     replicationpid=${!}
   elif [ "$UPDATE_MODE" == "catch-up" ]; then
     echo "starting replication once in catch-up mode"
-    sudo -u nominatim nominatim replication --project-dir /nominatim --catch-up &> /var/log/replication.log &
+    sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --catch-up &> /var/log/replication.log &
     replicationpid=${!}
   else
     echo "skipping replication"

--- a/4.1/start.sh
+++ b/4.1/start.sh
@@ -47,4 +47,8 @@ fi
 # fork a process and wait for it
 tail -Fv /var/log/postgresql/postgresql-14-main.log /var/log/apache2/access.log /var/log/apache2/error.log /var/log/replication.log &
 tailpid=${!}
+
+echo "Warm database caches for search and reverse queries"
+sudo -E -u nominatim nominatim admin --warm > /dev/null
+echo "Warming finished"
 wait

--- a/4.1/start.sh
+++ b/4.1/start.sh
@@ -25,7 +25,6 @@ if [ ! -f ${IMPORT_FINISHED} ]; then
   /app/init.sh
   touch ${IMPORT_FINISHED}
 else
-  rm -f /etc/postgresql/14/main/conf.d/postgres-import.conf
   chown -R nominatim:nominatim ${PROJECT_DIR}
 fi
 

--- a/4.1/start.sh
+++ b/4.1/start.sh
@@ -25,6 +25,7 @@ if [ ! -f ${IMPORT_FINISHED} ]; then
   /app/init.sh
   touch ${IMPORT_FINISHED}
 else
+  rm -f /etc/postgresql/14/main/conf.d/postgres-import.conf
   chown -R nominatim:nominatim ${PROJECT_DIR}
 fi
 

--- a/4.1/start.sh
+++ b/4.1/start.sh
@@ -37,11 +37,23 @@ service apache2 start
 
 # start continous replication process
 if [ "$REPLICATION_URL" != "" ] && [ "$FREEZE" != "true" ]; then
-  echo "starting replication"
   # run init in case replication settings changed
   sudo -u nominatim nominatim replication --project-dir /nominatim --init
-  sudo -u nominatim nominatim replication --project-dir /nominatim &> /var/log/replication.log &
-  replicationpid=${!}
+  if [ "$UPDATE_MODE" == "continuous" ]; then
+    echo "starting continuous replication"
+    sudo -u nominatim nominatim replication --project-dir /nominatim &> /var/log/replication.log &
+    replicationpid=${!}
+  elif [ "$UPDATE_MODE" == "once" ]; then
+    echo "starting replication once"
+    sudo -u nominatim nominatim replication --project-dir /nominatim --once &> /var/log/replication.log &
+    replicationpid=${!}
+  elif [ "$UPDATE_MODE" == "catch-up" ]; then
+    echo "starting replication once in catch-up mode"
+    sudo -u nominatim nominatim replication --project-dir /nominatim --catch-up &> /var/log/replication.log &
+    replicationpid=${!}
+  else
+    echo "skipping replication"
+  fi
 fi
 
 # fork a process and wait for it


### PR DESCRIPTION
start continuous replication process in start.sh to keep nominatim up-to-date if `REPLICATION_URL` is set and `FREEZE` is not set to `true`

I added `UPDATE_MODE` to configure how to run replication

- `UPDATE_MODE`: How to run replication to [update nominatim data](https://nominatim.org/release-docs/4.1.0/admin/Update/#updating-nominatim). Options: `continuous`/`once`/`catch-up`/`none` (default: `none`)

also fix the issue that postgres and apache are not stopped properly when the docker container is stopped.

when command is set as string, docker will launch the script in /bin/sh and the actual script will run in a subshell and not receive the signals. with ["/app/start.sh"] the script runs directly as PID 1 and properly executes the shutdown trap

also forward apache logs to docker

also warm cache after each startup