### PR TITLE
Pass environment variables to more sudo commands

### DIFF
--- a/4.1/start.sh
+++ b/4.1/start.sh
@@ -37,18 +37,18 @@ service apache2 start
 # start continous replication process
 if [ "$REPLICATION_URL" != "" ] && [ "$FREEZE" != "true" ]; then
   # run init in case replication settings changed
-  sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --init
+  sudo -E -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --init
   if [ "$UPDATE_MODE" == "continuous" ]; then
     echo "starting continuous replication"
-    sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} &> /var/log/replication.log &
+    sudo -E -u nominatim nominatim replication --project-dir ${PROJECT_DIR} &> /var/log/replication.log &
     replicationpid=${!}
   elif [ "$UPDATE_MODE" == "once" ]; then
     echo "starting replication once"
-    sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --once &> /var/log/replication.log &
+    sudo -E -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --once &> /var/log/replication.log &
     replicationpid=${!}
   elif [ "$UPDATE_MODE" == "catch-up" ]; then
     echo "starting replication once in catch-up mode"
-    sudo -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --catch-up &> /var/log/replication.log &
+    sudo -E -u nominatim nominatim replication --project-dir ${PROJECT_DIR} --catch-up &> /var/log/replication.log &
     replicationpid=${!}
   else
     echo "skipping replication"


### PR DESCRIPTION
This is an extension to https://github.com/mediagis/nominatim-docker/pull/308 where we also need to pass the environment variables on replication-related commands to ensure NOMINATIM_DATABASE_DSN is passed correctly, especially when we are working with external Postgres database like RDS. 