### PR TITLE
add info that Nominatim is ready

### DIFF
--- a/4.1/start.sh
+++ b/4.1/start.sh
@@ -62,4 +62,7 @@ tailpid=${!}
 echo "Warm database caches for search and reverse queries"
 sudo -E -u nominatim nominatim admin --warm > /dev/null
 echo "Warming finished"
+
+echo "--> Nominatim is ready to accept requests"
+
 wait

--- a/4.2/start.sh
+++ b/4.2/start.sh
@@ -62,4 +62,7 @@ tailpid=${!}
 echo "Warm database caches for search and reverse queries"
 sudo -E -u nominatim nominatim admin --warm > /dev/null
 echo "Warming finished"
+
+echo "--> Nominatim is ready to accept requests"
+
 wait


### PR DESCRIPTION
To some users it is not clear when the import is done & Nominatim is ready to accept requests (https://github.com/mediagis/nominatim-docker/discussions/397). I've added a simple echo after the startup to indicate that the startup is done.