### PR TITLE
Set default thread count based on nproc

### DIFF
--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -133,8 +133,6 @@ COPY --from=build / /
 
 # Please override this
 ENV NOMINATIM_PASSWORD=qaIACxO6wMR3
-# how many threads should be use for importing
-ENV THREADS=16
 
 ENV PROJECT_DIR=/nominatim
 

--- a/4.2/README.md
+++ b/4.2/README.md
@@ -54,7 +54,7 @@ The following environment variables are available for configuration:
 - `IMPORT_US_POSTCODES`: Whether to download and import the US postcode dump (`true`) or path to US postcode dump in the container. (default: `false`)
 - `IMPORT_GB_POSTCODES`: Whether to download and import the GB postcode dump (`true`) or path to GB postcode dump in the container. (default: `false`)
 - `IMPORT_TIGER_ADDRESSES`: Whether to download and import the Tiger address data (`true`) or path to a preprocessed Tiger address set in the container. (default: `false`)
-- `THREADS`: How many threads should be used to import (default: `16`)
+- `THREADS`: How many threads should be used to import (default: number of processing units available to the current process via `nproc`)
 - `NOMINATIM_PASSWORD`: The password to connect to the database with (default: `qaIACxO6wMR3`)
 
 The following run parameters are available for configuration:

--- a/4.2/contrib/docker-compose-planet.yml
+++ b/4.2/contrib/docker-compose-planet.yml
@@ -11,7 +11,6 @@ services:
     nominatim:
         container_name: nominatim
         image: mediagis/nominatim:4.2
-        restart: always
         ports:
             - "8080:8080" # Do not change the second port, only the first before the colon
         environment:

--- a/4.2/init.sh
+++ b/4.2/init.sh
@@ -6,6 +6,14 @@ CURL=("curl" "-L" "-A" "${USER_AGENT}" "--fail-with-body")
 
 SCP='sshpass -p DMg5bmLPY7npHL2Q scp -o StrictHostKeyChecking=no u355874-sub1@u355874-sub1.your-storagebox.de'
 
+# Check if THREADS is not set or is empty
+if [ -z "$THREADS" ]; then
+  THREADS=$(nproc)
+fi
+
+# Export so it's available for any process run after this script
+export THREADS
+
 if [ "$IMPORT_WIKIPEDIA" = "true" ]; then
   echo "Downloading Wikipedia importance dump"
   ${SCP}:wikimedia-importance.sql.gz ${PROJECT_DIR}/wikimedia-importance.sql.gz

--- a/4.2/init.sh
+++ b/4.2/init.sh
@@ -11,9 +11,6 @@ if [ -z "$THREADS" ]; then
   THREADS=$(nproc)
 fi
 
-# Export so it's available for any process run after this script
-export THREADS
-
 if [ "$IMPORT_WIKIPEDIA" = "true" ]; then
   echo "Downloading Wikipedia importance dump"
   ${SCP}:wikimedia-importance.sql.gz ${PROJECT_DIR}/wikimedia-importance.sql.gz

--- a/4.3/Dockerfile
+++ b/4.3/Dockerfile
@@ -137,8 +137,6 @@ COPY --from=build / /
 
 # Please override this
 ENV NOMINATIM_PASSWORD=qaIACxO6wMR3
-# how many threads should be use for importing
-ENV THREADS=16
 
 ENV PROJECT_DIR=/nominatim
 

--- a/4.3/README.md
+++ b/4.3/README.md
@@ -54,7 +54,7 @@ The following environment variables are available for configuration:
 - `IMPORT_US_POSTCODES`: Whether to download and import the US postcode dump (`true`) or path to US postcode dump in the container. (default: `false`)
 - `IMPORT_GB_POSTCODES`: Whether to download and import the GB postcode dump (`true`) or path to GB postcode dump in the container. (default: `false`)
 - `IMPORT_TIGER_ADDRESSES`: Whether to download and import the Tiger address data (`true`) or path to a preprocessed Tiger address set in the container. (default: `false`)
-- `THREADS`: How many threads should be used to import (default: `16`)
+- `THREADS`: How many threads should be used to import (default: number of processing units available to the current process via `nproc`)
 - `NOMINATIM_PASSWORD`: The password to connect to the database with (default: `qaIACxO6wMR3`)
 
 The following run parameters are available for configuration:

--- a/4.3/init.sh
+++ b/4.3/init.sh
@@ -6,6 +6,14 @@ CURL=("curl" "-L" "-A" "${USER_AGENT}" "--fail-with-body")
 
 SCP='sshpass -p DMg5bmLPY7npHL2Q scp -o StrictHostKeyChecking=no u355874-sub1@u355874-sub1.your-storagebox.de'
 
+# Check if THREADS is not set or is empty
+if [ -z "$THREADS" ]; then
+  THREADS=$(nproc)
+fi
+
+# Export so it's available for any process run after this script
+export THREADS
+
 if [ "$IMPORT_WIKIPEDIA" = "true" ]; then
   echo "Downloading Wikipedia importance dump"
   ${SCP}:wikimedia-importance.sql.gz ${PROJECT_DIR}/wikimedia-importance.sql.gz

--- a/4.3/init.sh
+++ b/4.3/init.sh
@@ -11,9 +11,6 @@ if [ -z "$THREADS" ]; then
   THREADS=$(nproc)
 fi
 
-# Export so it's available for any process run after this script
-export THREADS
-
 if [ "$IMPORT_WIKIPEDIA" = "true" ]; then
   echo "Downloading Wikipedia importance dump"
   ${SCP}:wikimedia-importance.sql.gz ${PROJECT_DIR}/wikimedia-importance.sql.gz


### PR DESCRIPTION
fixes https://github.com/mediagis/nominatim-docker/issues/458

sets the default amount of threads to the cpus available via `nproc` while still allowing the override with the existing THREADS environment variable. 

