### PR TITLE
Use date-based tag rather than git SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,10 +246,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set container date tag
+        run: |
+          echo "DATE_TAG=$(date +%Y-%m-%dT%H-%M)" >> $GITHUB_ENV
+
       - name: Build and push production docker image to Dockerhub
         if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'mediagis' }}
         run: |-
           docker buildx build --platform linux/amd64,linux/arm64 --push \
             -t mediagis/nominatim:${{ matrix.nominatim.version }} \
-            -t mediagis/nominatim:${{ matrix.nominatim.version }}-${{ github.sha }} .
+            -t mediagis/nominatim:${{ matrix.nominatim.version }}-${DATE_TAG} .
         working-directory: ${{ matrix.nominatim.version }}


### PR DESCRIPTION
When I used the git SHA hashes originally I thought that I would be interested in knowing the exact version of an image. It turns out that in several years of using this image, I never looked at it and just want an identifier that is easy to parse for humans.

For this reason I'm switching to date-based tags. If you want to see what it looks like, you can take a look at OpenTripPlanner's repo: https://hub.docker.com/r/opentripplanner/opentripplanner/tags

