### PR TITLE
Add checkout step to publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,9 @@ jobs:
           - version: "4.4"
   
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
The master branch build failed and I believe it was because of a missing checkout action.

cc @carlomion 