### PR TITLE
Bugfix: Dockerfile RUN cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,11 +276,11 @@ jobs:
           # Disable generation of latest tag
           flavor: |
             latest=false
-            prefix=${{ matrix.nominatim.version }}
           
-          # Customize the date format
+          # Add simple tag with nominatim version + tag with custom date format
           tags: |
-            type=schedule,pattern={{date 'YYYY-MM-DDTHH-mm'}},prefix=-
+            type=raw,value=${{ matrix.nominatim.version }}
+            type=raw,value=${{ matrix.nominatim.version }}-{{date 'YYYY-MM-DDTHH-mm'}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+      
+      # Compute the Docker tags and labels to apply to the built image
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # List of Docker images to use as base name for tags
+          images: |
+            mediagis/nominatim        
+          
+          # Disable generation of latest tag
+          flavor: |
+            latest=false
+            prefix=${{ matrix.nominatim.version }}
+          
+          # Customize the date format
+          tags: |
+            type=schedule,pattern={{date 'YYYY-MM-DDTHH-mm'}},prefix=-
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -274,14 +292,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      - name: Set container date tag
-        run: |
-          echo "DATE_TAG=$(date +%Y-%m-%dT%H-%M)" >> $GITHUB_ENV
-
-      - name: Build and push production docker image to Dockerhub
-        if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'mediagis' }}
-        run: |-
-          docker buildx build --platform linux/amd64,linux/arm64 --push \
-            -t mediagis/nominatim:${{ matrix.nominatim.version }} \
-            -t mediagis/nominatim:${{ matrix.nominatim.version }}-${DATE_TAG} .
-        working-directory: ${{ matrix.nominatim.version }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.nominatim.version }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'mediagis' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -29,7 +29,6 @@ RUN  \
         -o APT::Install-Suggests="false" \
         # Build tools from sources.
         build-essential \
-        g++ \
         cmake \
         libpq-dev \
         zlib1g-dev \
@@ -99,18 +98,13 @@ RUN true \
 
 RUN true \
     # Remove development and unused packages.
-    && apt-get -y remove --purge \
-        cpp-9 \
-        gcc-9* \
-        g++ \
+    && apt-get -y remove --purge --auto-remove \
+        build-essential \
+        cmake \
         git \
-        make \
-        cmake* \
         llvm-10* \
-        libc6-dev \
         linux-libc-dev \
         libclang-*-dev \
-        build-essential \
         liblua*-dev \
         postgresql-server-dev-14 \
         nlohmann-json3-dev \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -8,8 +8,13 @@ ENV LANG=C.UTF-8
 
 WORKDIR /app
 
-RUN \
-    --mount=type=cache,target=/var/cache/apt \
+# Inspired by https://github.com/reproducible-containers/buildkit-cache-dance?tab=readme-ov-file#apt-get-github-actions
+RUN  \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    # Keep downloaded APT packages in the docker build cache
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
     # Do not start daemons after installation.
     echo '#!/bin/sh\nexit 101' > /usr/sbin/policy-rc.d \
     && chmod +x /usr/sbin/policy-rc.d \
@@ -76,7 +81,7 @@ RUN true \
     && echo "listen_addresses='*'" >> /etc/postgresql/14/main/postgresql.conf
 
 # Osmium install to run continuous updates.
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip3 install osmium
 
 # Nominatim install.
@@ -114,7 +119,6 @@ RUN true \
         /tmp/* \
         /var/tmp/* \
         /app/src/.git \
-        /var/lib/apt/lists/* \
     # Remove nominatim source and build directories
     && rm /app/*.tar.bz2 \
     && rm -rf /app/build \


### PR DESCRIPTION
Following the introduction of the Dockerfile RUN cache in #554 , the build has started failing, likely due to concurrent access to the same cached folder during the multi-architecture build process: https://github.com/mediagis/nominatim-docker/actions/runs/8722047757

This PR does the following:
- avoid sharing of the cache
- uses the `docker/metadata-action@v5` to define the Docker label and tag for the image
- the `docker build` is always done in the CI pipeline, so that the arm64 build is also built, but only pushed to Dockerhub if on the `master` branch