### PR TITLE
fix: set executable permission for shell scripts in dockerfile

### DIFF
--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -130,6 +130,7 @@ COPY init.sh /app/init.sh
 COPY start.sh /app/start.sh
 COPY startapache.sh /app/startapache.sh
 COPY startpostgres.sh /app/startpostgres.sh
+RUN chmod -x /app/*.sh
 
 # Collapse image to single layer.
 FROM scratch


### PR DESCRIPTION
had this error:

`docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process`

i added a run command to set the. executable permission on all .sh files within the app directory