### PR TITLE
Mounted volume group ownership fix

### DIFF
--- a/4.4/init.sh
+++ b/4.4/init.sh
@@ -65,7 +65,7 @@ fi
 
 # if we use a bind mount then the PG directory is empty and we have to create it
 if [ ! -f /var/lib/postgresql/14/main/PG_VERSION ]; then
-  chown postgres /var/lib/postgresql/14/main
+  chown postgres:postgres /var/lib/postgresql/14/main
   sudo -u postgres /usr/lib/postgresql/14/bin/initdb -D /var/lib/postgresql/14/main
 fi
 


### PR DESCRIPTION
When attempting to host this image in K8S with a persistent volume, the permission on the postgres directory were not correct. 

```
 Error: The cluster is owned by group id *** which does not exist
```
I'm overriding the default command to set the permissions correctly using 

```
`mkdir -p /var/lib/postgresql/14/main && sudo chown postgres:postgres /var/lib/postgresql/14/main && bash /app/start.sh`
```