### PR TITLE
Add ENABLE_WARMUP parameter

### DIFF
--- a/4.5/README.md
+++ b/4.5/README.md
@@ -63,6 +63,7 @@ Other places at Geofabrik follow the pattern `https://download.geofabrik.de/$CON
 - `IMPORT_TIGER_ADDRESSES`: Whether to download and import the Tiger address data (`true`) or path to a preprocessed Tiger address set in the container. (default: `false`)
 - `THREADS`: How many threads should be used to import (default: number of processing units available to the current process via `nproc`)
 - `NOMINATIM_PASSWORD`: The password to connect to the database with (default: `qaIACxO6wMR3`)
+- `ENABLE_WARMUP`: Enable or disable database warmup. Skipping warmup allows the container to answer requests immediately but possibly slower. (default: true)
 
 The following run parameters are available for configuration:
 

--- a/4.5/example.md
+++ b/4.5/example.md
@@ -62,6 +62,9 @@ docker run -it \
   #Sets the used threads at the import (default 16)
   -e THREADS=10 \
 
+  #Enable or disable database warmup. Skipping warmup allows the container to answer requests immediately but possibly slower. (default: true)
+  -e ENABLE_WARMUP=true/false
+
   #Sets the Docker tmpfs. Highly recommended for bigger imports like Europe. At least 1GB - ideally half of the available RAM. 
   --shm-size=60g \
 


### PR DESCRIPTION
I added the parameter `ENABLE_WARMUP` to the `start.sh` script.

This new parameter allows skipping the database warmup routine after the container restarts. 
Useful for answering requests immediately after the container starts.

Default value is `true` for backwards compatibility.
