### PR TITLE
Install icu and datrie python packages from Ubuntu repos

### DIFF
--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -34,6 +34,8 @@ RUN  \
         libicu-dev \
         python3-dev \
         python3-pip \
+        python3-icu \
+        python3-datrie \
         # PostgreSQL.
         postgresql-contrib \
         postgresql-server-dev-16 \


### PR DESCRIPTION
I want to try if this makes building the image any faster.

According to @lonvia pip is smart enough to figure out that the package already exists and doesn't compile them from scratch.