### PR TITLE
Add configurable Gunicorn worker count with default fallback

### DIFF
--- a/5.1/README.md
+++ b/5.1/README.md
@@ -62,7 +62,7 @@ Other places at Geofabrik follow the pattern `https://download.geofabrik.de/$CON
 - `IMPORT_GB_POSTCODES`: Whether to download and import the GB postcode dump (`true`) or path to GB postcode dump in the container. (default: `false`)
 - `IMPORT_TIGER_ADDRESSES`: Whether to download and import the Tiger address data (`true`) or path to a preprocessed Tiger address set in the container. (default: `false`)
 - `THREADS`: How many threads should be used to import (default: number of processing units available to the current process via `nproc`)
-- `GUNICORN_WORKERS`: How many Gunicorn worker processes should handle API requests (default: 4). Increase this value for higher concurrent request handling capacity.
+- `GUNICORN_WORKERS`: Specifies how many Gunicorn worker processes should handle API requests. If not explicitly set, it defaults to the number of available CPU cores `(nproc)`. Increase this value to improve concurrent request handling capacity, but ensure it aligns with your server's CPU resources.
 - `NOMINATIM_PASSWORD`: The password to connect to the database with (default: `qaIACxO6wMR3`)
 
 The following run parameters are available for configuration:

--- a/5.1/README.md
+++ b/5.1/README.md
@@ -62,6 +62,7 @@ Other places at Geofabrik follow the pattern `https://download.geofabrik.de/$CON
 - `IMPORT_GB_POSTCODES`: Whether to download and import the GB postcode dump (`true`) or path to GB postcode dump in the container. (default: `false`)
 - `IMPORT_TIGER_ADDRESSES`: Whether to download and import the Tiger address data (`true`) or path to a preprocessed Tiger address set in the container. (default: `false`)
 - `THREADS`: How many threads should be used to import (default: number of processing units available to the current process via `nproc`)
+- `GUNICORN_WORKERS`: How many Gunicorn worker processes should handle API requests (default: 4). Increase this value for higher concurrent request handling capacity.
 - `NOMINATIM_PASSWORD`: The password to connect to the database with (default: `qaIACxO6wMR3`)
 
 The following run parameters are available for configuration:

--- a/5.1/start.sh
+++ b/5.1/start.sh
@@ -82,7 +82,7 @@ echo "Warming finished"
 
 # Set default number of workers if not specified
 if [ -z "$GUNICORN_WORKERS" ]; then
-  GUNICORN_WORKERS=4
+  GUNICORN_WORKERS=$(nproc)
 fi
 
 echo "Starting Gunicorn with $GUNICORN_WORKERS workers"

--- a/5.1/start.sh
+++ b/5.1/start.sh
@@ -80,13 +80,20 @@ export NOMINATIM_QUERY_TIMEOUT=10
 export NOMINATIM_REQUEST_TIMEOUT=60
 echo "Warming finished"
 
+# Set default number of workers if not specified
+if [ -z "$GUNICORN_WORKERS" ]; then
+  GUNICORN_WORKERS=4
+fi
+
+echo "Starting Gunicorn with $GUNICORN_WORKERS workers"
+
 echo "--> Nominatim is ready to accept requests"
 
 cd "$PROJECT_DIR"
 sudo -u nominatim gunicorn \
   --bind :8080 \
   --pid $GUNICORN_PID_FILE \
-  --workers 4 \
+  --workers $GUNICORN_WORKERS \
   --daemon \
   --enable-stdio-inheritance \
   --worker-class uvicorn.workers.UvicornWorker \


### PR DESCRIPTION
This change introduces a new environment variable `GUNICORN_WORKERS` to control the number of Gunicorn worker processes handling API requests.

- If `GUNICORN_WORKERS` is not set, it defaults to `4`.

- This allows easier tuning of the API server’s concurrency and resource usage based on deployment needs.

- Logs the worker count on startup for better visibility.