### PR TITLE
feat: wait for Postgres to be up and running before starting gunicorn

### DIFF
--- a/5.1/contrib/docker-compose.yml
+++ b/5.1/contrib/docker-compose.yml
@@ -10,6 +10,7 @@ services:
             # see https://github.com/mediagis/nominatim-docker/tree/master/5.1#configuration for more options
             PBF_URL: https://download.geofabrik.de/europe/monaco-latest.osm.pbf
             REPLICATION_URL: https://download.geofabrik.de/europe/monaco-updates/
+            WAIT_FOR_POSTGRES: false
             NOMINATIM_PASSWORD: very_secure_password
         volumes:
             - nominatim-data:/var/lib/postgresql/16/main

--- a/5.1/start.sh
+++ b/5.1/start.sh
@@ -80,12 +80,14 @@ export NOMINATIM_QUERY_TIMEOUT=10
 export NOMINATIM_REQUEST_TIMEOUT=60
 echo "Warming finished"
 
-# Wait for PostgreSQL to be ready
-echo "Waiting for PostgreSQL to be ready..."
-until pg_isready -h localhost -p 5432 -U postgres; do
-  echo "PostgreSQL is unavailable - sleeping"
-  sleep 1
-done
+if [ "$WAIT_FOR_POSTGRES" = "true" ]; then
+    # Wait for PostgreSQL to be ready
+    echo "Waiting for PostgreSQL to be ready..."
+    until pg_isready -h localhost -p 5432 -U postgres; do
+      echo "PostgreSQL is unavailable - sleeping"
+      sleep 1
+    done
+fi
 echo "PostgreSQL is up - continuing"
 
 # Set default number of workers if not specified


### PR DESCRIPTION
Every statement here is a guess of mine, but this worked for me.

The problem for me was, gunicorn started faster than Postgres was ready. So these lines:

```
tail -Fv /var/log/postgresql/postgresql-16-main.log &
tailpid=${!}
```

only check if Postgres is running, not accepting new connections. That lead to 404 errors and the api does not recover automatically from a non-running Postgres. See https://github.com/mediagis/nominatim-docker/issues/607 for details. I added a `pg_isready` loop to wait for Postgres actually being ready before starting the api.