### PR TITLE
allow setting POSTGRES_MAX_CONNECTIONS

### DIFF
--- a/5.1/README.md
+++ b/5.1/README.md
@@ -82,6 +82,7 @@ The following environment variables are available to tune PostgreSQL:
 - `POSTGRES_MAX_WAL_SIZE` (default: `1GB`)
 - `POSTGRES_CHECKPOINT_TIMEOUT` (default: `10min`)
 - `POSTGRES_CHECKPOINT_COMPLETION_TARGET` (default: `0.9`)
+- `POSTGRES_MAX_CONNECTIONS` (default: `100`)
 
 See https://nominatim.org/release-docs/5.1/admin/Installation/#tuning-the-postgresql-database for more details on those settings.
 

--- a/5.1/config.sh
+++ b/5.1/config.sh
@@ -41,7 +41,7 @@ if [ ! -z "$POSTGRES_SYNCHRONOUS_COMMIT" ]; then sed -i "s/synchronous_commit = 
 if [ ! -z "$POSTGRES_MAX_WAL_SIZE" ]; then sed -i "s/max_wal_size = 1GB/max_wal_size = $POSTGRES_MAX_WAL_SIZE/g" /etc/postgresql/16/main/conf.d/postgres-tuning.conf; fi
 if [ ! -z "$POSTGRES_CHECKPOINT_TIMEOUT" ]; then sed -i "s/checkpoint_timeout = 10min/checkpoint_timeout = $POSTGRES_CHECKPOINT_TIMEOUT/g" /etc/postgresql/16/main/conf.d/postgres-tuning.conf; fi
 if [ ! -z "$POSTGRES_CHECKPOINT_COMPLETION_TARGET" ]; then sed -i "s/checkpoint_completion_target = 0.9/checkpoint_completion_target = $POSTGRES_CHECKPOINT_COMPLETION_TARGET/g" /etc/postgresql/16/main/conf.d/postgres-tuning.conf; fi
-
+if [ ! -z "$POSTGRES_MAX_CONNECTIONS" ]; then echo "max_connections = $POSTGRES_MAX_CONNECTIONS" >> /etc/postgresql/16/main/conf.d/postgres-tuning.conf; fi
 
 # import style tuning
 


### PR DESCRIPTION
for https://github.com/mediagis/nominatim-docker/issues/622

For those users who see "sorry, too many clients already" warnings in postgresql logfile.