### PR TITLE
Pin version for nominatim-api in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked pip install --brea
     falcon \
     uvicorn \
     gunicorn \
-    nominatim-api
+    nominatim-api==$NOMINATIM_VERSION
 
 
 # remove build-only packages


### PR DESCRIPTION
only the nominatim-db dep is pinned. this change will prevent weird issues or misalignment.

Generally i would reccomend moving to poetry or better yet uv and have lockfile and use it to install so all deps have a predictable version