### PR TITLE
fix: Update URL path in README for Nominatim API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker run -it \
   mediagis/nominatim:5.2
 ```
 
-After the import is complete, you can access the Nominatim API at `http://localhost:8080/search.php?q=avenue%20pasteur`.
+After the import is complete, you can access the Nominatim API at `http://localhost:8080/search?q=avenue%20pasteur`.
 
 ## Accessing Different Versions
 


### PR DESCRIPTION
As per the Nominatim [docs], performing search queries at `https://<hostname>/search.php?<params>` is now deprecated and should use `https://<hostname>/search?<params>` instead.

[docs]: https://nominatim.org/release-docs/develop/api/Search/