### PR TITLE
feat(imports): add a bash script for supporting multi .pbf file or url import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN  \
     && apt-get -y update -qq \
     && apt-get -y install \
         locales \
-        osmium-tool \  
+        osmctools \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 \
     && apt-get -y install \


### PR DESCRIPTION
i add a bash script for importing multi PBF file and then merging them and start the main process in the merged file.
files paths or  urls should be inside a string and a <space> between them in PBF_URL or PBF_PATH env variable.

```
docker run -it \
  -e PBF_URL="https://download.geofabrik.de/asia/iran-251125.osm.pbf https://download.geofabrik.de/asia/iraq-latest.osm.pbf" \
  -p 8080:8080 \
  --name nominatim \
  --env REVERSE_ONLY=true \
  --env IMPORT_STYLE=address \
  nominatim:latest
```

