### PR TITLE
Fix PATH for Wikipedia secondary importance

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -28,7 +28,7 @@ fi;
 
 if [ "$IMPORT_SECONDARY_WIKIPEDIA" = "true" ]; then
   echo "Downloading Wikipedia secondary importance dump"
-  ${SCP}:wikimedia-importance-secondary.sql.gz ${PROJECT_DIR}/secondary_importance.sql.gz
+  ${SCP}:wikimedia-secondary-importance.sql.gz ${PROJECT_DIR}/secondary_importance.sql.gz
 elif [ -f "$IMPORT_SECONDARY_WIKIPEDIA" ]; then
   # use local file if asked
   ln -s "$IMPORT_SECONDARY_WIKIPEDIA" ${PROJECT_DIR}/secondary_importance.sql.gz


### PR DESCRIPTION
This PR fixes a typo in the init.sh script that causes the download of the Wikipedia secondary importance dump to fail.

**Issue**: The script attempts to download wikimedia-importance-secondary.sql.gz.

**Fix**: Updated the filename to wikimedia-secondary-importance.sql.gz to match the actual file located on the Hetzner storage box.

Without this fix, the build fails with a No such file or directory error when IMPORT_SECONDARY_WIKIPEDIA=true